### PR TITLE
Improved Finnish and Sami names and Utf-8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ These are the accepted names of cultures:
 - uyghur
 - rajput
 
-Note: Some provinces/settlements have the culture "tbd" because they were originally categorized incorrectly. If you recognize them, please fork this project and make the change.
+**Note:** Some provinces/settlements have the culture `tbd` because they were originally categorized incorrectly. If you recognize them, please fork this project and make the change.

--- a/README.md
+++ b/README.md
@@ -187,3 +187,5 @@ These are the accepted names of cultures:
 - armenian
 - uyghur
 - rajput
+
+Note: Some provinces/settlements have the culture "tbd" because they were originally categorized incorrectly. If you recognize them, please fork this project and make the change.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ These are the accepted names of cultures:
 - hindustani
 - egyptian_arabic
 - telugu
-- lappish
+- northern_sami
 - karluk
 - sumpa
 - occitan

--- a/not_constantinople.py
+++ b/not_constantinople.py
@@ -1,12 +1,13 @@
 from os import getcwd, listdir, mkdir
 from os.path import isdir
 from json import loads
+import io
 import markovify
 
 
 # Returns all provinces and their settlements with a given culture.
 def get_culture(culture):
-    with open(getcwd() + "/provinces.json", 'rt') as f:
+    with io.open(getcwd() + "/provinces.json", mode='rt', encoding="utf-8") as f:
         provinces = loads(f.read())
         c_p = dict()
         for key in provinces.keys():
@@ -77,13 +78,13 @@ def generate(filename, filename_suffix, dataset):
     directory = getcwd() + "/Output"
     if not isdir(directory):
         mkdir(directory)
-    with open(directory + "/" + filename + "_" + filename_suffix + ".txt", "wt") as f:
+    with io.open(directory + "/" + filename + "_" + filename_suffix + ".txt", mode="wt", encoding="utf-8") as f:
         f.writelines(generated)
-            
+
 
 # Load the stored cultural blends and generate some names.
 for f in listdir(getcwd() + "/Input"):
-    with open(getcwd() + "/Input/" + f, "rt") as j:
+    with io.open(getcwd() + "/Input/" + f, mode="rt", encoding="utf-8") as j:
         # Get the saved cultural blend.
         json_culture = loads(j.read())
         # Generate names of provinces and settlements.

--- a/provinces.json
+++ b/provinces.json
@@ -2473,7 +2473,7 @@
     },
     "Lappi": {
         "settlements": ["Giron", "Arjepluovvi", "Árviesjávrrie", "Jiellevárri", "Johkamohkki", "Suorssá"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Lappland": {
         "settlements": ["Gallivare", "Dorotea", "Sorsele", "Mala", "Vilhelmina", "Asele"],
@@ -2481,7 +2481,7 @@
     },
     "Norrbotten": {
         "settlements": ["Bájil", "Biđona", "Bodena", "Gáinnasa", "Háhpáránddi"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Norrbotten": {
         "settlements": ["Pitea", "Boden", "Kalix", "Lulea", "Alvsbyn"],
@@ -3021,7 +3021,7 @@
     },
     "Sápmi": {
         "settlements": ["Njávdán", "Roavvenjárga", "Giemajávri", "Suovvaguoika", "Ohcejohka", "Anár", "Duortnus", "Soađegilli", "Pello", "Eanodat", "Giepma", "Gihttel", "Muoná"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Lappi": {
         "settlements": ["Näätämö", "Rovaniemi", "Kemijärvi", "Savukoski", "Inari", "Tornio", "Sodankylä", "Pello", "Enontekiö", "Kittilä", "Muonio"],
@@ -3029,7 +3029,7 @@
     },
     "Beahcán": {
         "settlements": [],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Petsamo": {
         "settlements": ["Höyhenjärvi"],
@@ -3037,7 +3037,7 @@
     },
     "Guoládat": {
         "settlements": [],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Kola": {
         "settlements": ["Jekanskoi", "Tre", "Pechenga", "Lovozero", "Waranger", "Molovskoi", "Mafelskoi"],
@@ -3045,7 +3045,7 @@
     },
     "Finnmárk": {
         "settlements": ["Ákŋoluokta", "Álaheadju", "Báhcavuotna", "Bearalváhki", "Čáhcesuolu", "Davvesiida", "Davvinjárga", "Deatnu", "Fálesnuorri", "Gáŋgaviika", "Guovdageaidnu", "Hámmárfeasta", "Kárášjohka", "Láhppi", "Mátta-Várjjat", "Muosát", "Porsáŋgu", "Unjárga", "Várggát"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Finnmark": {
         "settlements": ["Malangen", "Hammerfest", "Ostervagen", "Piselvnes", "Vardohus", "Karsloy"],
@@ -3053,7 +3053,7 @@
     },
     "Romsa": {
         "settlements": ["Báhccavuotna", "Beardu", "Birgi", "Divrrát", "Doasku", "Gáivuotna", "Gálsa", "Giehtavuotna", "Hárštá", "Ivgu", "Ivvárstáđit", "Leaŋgáviika", "Loabát", "Málatvuopmi", "Návuotna", "Omasvuotna", "Ránáidsuolu", "Ráisa", "Ráisavuotna", "Rivttát", "Siellat", "Skiervá", "Skánit"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Troms": {
         "settlements": ["Balsfjord", "Bardu", "Berg", "Harstad", "Kvaefjord", "Lenvik", "Malselv", "Nordreisa", "Skanland", "Tromso"],
@@ -3065,7 +3065,7 @@
     },
     "Nordlándda": {
         "settlements": ["Áhkánjárga", "Válafierda", "Bálat", "Ruovada", "Hábmir", "Sálát", "Ánddasuolu", "Báidár", "Árbordi", "Evenášši", "Vuogát", "Stáigu"],
-        "culture": "lappish"
+        "culture": "northern_sami"
     },
     "Nordland": {
         "settlements": ["Narvik", "Kabelvag", "Bodo", "Rodoy", "Harstad", "Rost", "Andenes", "Beiarn"],

--- a/provinces.json
+++ b/provinces.json
@@ -2472,20 +2472,32 @@
         "culture": "norse"
     },
     "Lappi": {
-        "settlements": ["Giron", "Arjepluovvi", "Árviesjávrrie", "Jiellevárri", "Johkamohkki"],
+        "settlements": ["Giron", "Arjepluovvi", "Árviesjávrrie", "Jiellevárri", "Johkamohkki", "Suorssá"],
+        "culture": "lappish"
+    },
+    "Lappland": {
+        "settlements": ["Gallivare", "Dorotea", "Sorsele", "Mala", "Vilhelmina", "Asele"],
+        "culture": "norse"
+    },
+    "Norrbotten": {
+        "settlements": ["Bájil", "Biđona", "Bodena", "Gáinnasa", "Háhpáránddi"],
         "culture": "lappish"
     },
     "Norrbotten": {
-        "settlements": ["Bájil", "Biđona", "Bodena", "Gáinnasa", "Háhpáránddi", "Luleju", "Älvsbyna"],
-        "culture": "lappish"
+        "settlements": ["Pitea", "Boden", "Kalix", "Lulea", "Alvsbyn"],
+        "culture": "norse"
+    },
+    "Pohjoispohja": {
+        "settlements": ["Haaparanta", "Ylikainuu", "Ylitornio", "Luulaja", "Pajala"],
+        "culture": "finnish"
     },
     "Somerset": {
         "settlements": ["Muchelney", "Wells", "Ilchester", "Taunton", "Castle Cary", "Bath", "Cleeve", "Glastonbury"],
         "culture": "saxon"
     },
-    "Västerbotten": {
-        "settlements": ["Dorotea", "Lycksele", "Malå", "Suorssá", "Skielleta", "Storumana", "Vilhelmina", "Åsele", "Ubmi"],
-        "culture": "lappish"
+    "Vasterbotten": {
+        "settlements": ["Umea", "Skellefteå"],
+        "culture": "norse"
     },
     "Angermanland": {
         "settlements": ["Ulvo", "Natra"],
@@ -2530,6 +2542,10 @@
     "Uppland": {
         "settlements": ["Sigtuna", "Stockholm", "Alsno", "Enkoping", "Birka", "Hatuna", "Osteras", "Uppsala"],
         "culture": "norse"
+    },
+    "Ahvenanmaa": {
+        "settlements": [],
+        "culture": "finnish"
     },
     "Aland": {
         "settlements": ["Sund", "Geta", "Kastelholm"],
@@ -3007,6 +3023,22 @@
         "settlements": ["Njávdán", "Roavvenjárga", "Giemajávri", "Suovvaguoika", "Ohcejohka", "Anár", "Duortnus", "Soađegilli", "Pello", "Eanodat", "Giepma", "Gihttel", "Muoná"],
         "culture": "lappish"
     },
+    "Lappi": {
+        "settlements": ["Näätämö", "Rovaniemi", "Kemijärvi", "Savukoski", "Inari", "Tornio", "Sodankylä", "Pello", "Enontekiö", "Kittilä", "Muonio"],
+        "culture": "finnish"
+    },
+    "Beahcán": {
+        "settlements": [],
+        "culture": "lappish"
+    },
+    "Petsamo": {
+        "settlements": ["Höyhenjärvi"],
+        "culture": "finnish"
+    },
+    "Guoládat": {
+        "settlements": [],
+        "culture": "lappish"
+    },
     "Kola": {
         "settlements": ["Jekanskoi", "Tre", "Pechenga", "Lovozero", "Waranger", "Molovskoi", "Mafelskoi"],
         "culture": "tbd"
@@ -3015,13 +3047,25 @@
         "settlements": ["Ákŋoluokta", "Álaheadju", "Báhcavuotna", "Bearalváhki", "Čáhcesuolu", "Davvesiida", "Davvinjárga", "Deatnu", "Fálesnuorri", "Gáŋgaviika", "Guovdageaidnu", "Hámmárfeasta", "Kárášjohka", "Láhppi", "Mátta-Várjjat", "Muosát", "Porsáŋgu", "Unjárga", "Várggát"],
         "culture": "lappish"
     },
+    "Finnmark": {
+        "settlements": ["Malangen", "Hammerfest", "Ostervagen", "Piselvnes", "Vardohus", "Karsloy"],
+        "culture": "Norse"
+    },
     "Romsa": {
-        "settlements": ["Báhccavuotna", "Beardu", "Bjarkøy", "Birgi", "Divrrát", "Doasku", "Gáivuotna", "Gálsa", "Giehtavuotna", "Hárštá", "Ivgu", "Ivvárstáđit", "Leaŋgáviika", "Loabát", "Málatvuopmi", "Návuotna", "Omasvuotna", "Ránáidsuolu", "Ráisa", "Ráisavuotna", "Rivttát", "Romsa", "Siellat", "Skiervá", "Skánit"],
+        "settlements": ["Báhccavuotna", "Beardu", "Birgi", "Divrrát", "Doasku", "Gáivuotna", "Gálsa", "Giehtavuotna", "Hárštá", "Ivgu", "Ivvárstáđit", "Leaŋgáviika", "Loabát", "Málatvuopmi", "Návuotna", "Omasvuotna", "Ránáidsuolu", "Ráisa", "Ráisavuotna", "Rivttát", "Siellat", "Skiervá", "Skánit"],
         "culture": "lappish"
+    },
+    "Troms": {
+        "settlements": ["Balsfjord", "Bardu", "Berg", "Harstad", "Kvaefjord", "Lenvik", "Malselv", "Nordreisa", "Skanland", "Tromso"],
+        "culture": "norse"
     },
     "Ross": {
         "settlements": ["Rosemarkie", "Cromarty", "Tain", "Dingwall", "Avoch", "Fortrose", "Applecross", "Fearn"],
         "culture": "pictish"
+    },
+    "Nordlándda": {
+        "settlements": ["Áhkánjárga", "Válafierda", "Bálat", "Ruovada", "Hábmir", "Sálát", "Ánddasuolu", "Báidár", "Árbordi", "Evenášši", "Vuogát", "Stáigu"],
+        "culture": "lappish"
     },
     "Nordland": {
         "settlements": ["Narvik", "Kabelvag", "Bodo", "Rodoy", "Harstad", "Rost", "Andenes", "Beiarn"],
@@ -3031,8 +3075,12 @@
         "settlements": ["Kaukola", "Raivola", "Antrea", "Räisälä", "Kuolemajärvi", "Koivisto", "Käkisalmi", "Terijoki"],
         "culture": "finnish"
     },
+    "Ääninen": {
+        "settlements": ["Karhumäki", "Aunus", "Kontupohja", "Tolvoja"],
+        "culture": "finnish"
+    },
     "Onega": {
-        "settlements": ["Ust-Onega", "Segezha", "Pryazha", "Aunus", "Petrozavodsk", "Pudoga", "Kondopoga"],
+        "settlements": ["Ust-Onega", "Segezha", "Pryazha", "Olonets", "Petrozavodsk", "Pudoga", "Kondopoga"],
         "culture": "tbd"
     },
     "Trans-Portage": {
@@ -5079,7 +5127,11 @@
         "settlements": ["Wittmund", "Leer", "Borkum", "Norden", "Aurich", "Emden", "Norderney", "Esens"],
         "culture": "frisian"
     },
-    "Kandalax": {
+    "Kantalahti": {
+        "settlements": ["Kantalahti", "Alakurtti", "Kairala"],
+        "culture": "finnish"
+    },
+    "Kandalaksha": {
         "settlements": ["Sarapo", "Pyaozero", "Ponoy", "Kandalaksha", "Kolsky", "Umba", "Lekastrom", "Varzuga"],
         "culture": "tbd"
     },

--- a/provinces.json
+++ b/provinces.json
@@ -3049,7 +3049,7 @@
     },
     "Finnmark": {
         "settlements": ["Malangen", "Hammerfest", "Ostervagen", "Piselvnes", "Vardohus", "Karsloy"],
-        "culture": "Norse"
+        "culture": "norse"
     },
     "Romsa": {
         "settlements": ["Báhccavuotna", "Beardu", "Birgi", "Divrrát", "Doasku", "Gáivuotna", "Gálsa", "Giehtavuotna", "Hárštá", "Ivgu", "Ivvárstáđit", "Leaŋgáviika", "Loabát", "Málatvuopmi", "Návuotna", "Omasvuotna", "Ránáidsuolu", "Ráisa", "Ráisavuotna", "Rivttát", "Siellat", "Skiervá", "Skánit"],

--- a/provinces.json
+++ b/provinces.json
@@ -1,1 +1,5474 @@
-{"Vestisland": {"settlements": ["Skalholt", "Borg", "Alftanes", "Kjalarnes", "Hlidarendi", "Reykjavik", "Hvamm", "Pingvellir"], "culture": "norse"}, "Kildare": {"settlements": ["Clonard", "Knockaulin", "Kildare", "Durrow", "Rathangan", "Athlone", "St Brigit", "Maynooth"], "culture": "irish"}, "Avranches": {"settlements": ["Mortain", "Bayeux", "Cherbourg", "Avranches", "Barfleur", "Coutances", "Domfront", "Caen"], "culture": "old_frankish"}, "Rennes": {"settlements": ["Dol", "Porhoet", "St Meen", "Dinan", "St Malo", "Rennes", "St Michel"], "culture": "breton"}, "Lori": {"settlements": ["Dzegh", "Dmanis", "Lori Berd"], "culture": "georgian"}, "Penthievre": {"settlements": ["Peran", "Quintin", "Chatelaudren", "St Brieuc", "Monkontour", "Loudeac", "Verdelet", "Paimpol"], "culture": "breton"}, "French Leon": {"settlements": ["Roscoff", "Guingamp", "St Pol De Leon", "Brest", "Morlaix", "Treguier", "Plourivo", "Plougonven"], "culture": "breton"}, "Cornouaille": {"settlements": ["Landevennec", "Quimper", "Huelgoat", "Carhaix", "Quimperle", "Lezergue", "Corlay", "Langonnet"], "culture": "breton"}, "Vannes": {"settlements": ["Pontivy", "Locmine", "Vannes", "Suscinio", "Auray", "Josselin", "Hennebont"], "culture": "breton"}, "Nantes": {"settlements": ["Guerande", "Chateaubriant", "La Roche-Bernard", "St Nazaire", "Donges", "Redon", "Nantes", "Clisson"], "culture": "breton"}, "Anjou": {"settlements": ["Treves", "Fontevraud", "Angers", "Saumur", "Chateaugontier", "Montsoreau", "Cholet"], "culture": "old_frankish"}, "Maine": {"settlements": ["Evron", "Craon", "Le Mans", "Mayenne", "Sable", "Laval", "Beaumont"], "culture": "old_frankish"}, "Vendome": {"settlements": ["Montmirail", "Freteval", "Montoire", "Cloyes", "Lavardin", "Chateaurenault", "Stavit", "Vendome"], "culture": "old_frankish"}, "Dublin": {"settlements": ["Ath Cliath", "Clondalkin", "Mellifont", "Wicklow", "Trim", "Christ Church", "Dublin", "Finglas"], "culture": "irish"}, "Blois": {"settlements": ["Chaumontsurloire", "Montrichard", "Stgeorgesdubois", "Staignan", "Romorantin", "Blois", "Fougeressurbievre"], "culture": "old_frankish"}, "Chartres": {"settlements": ["Nogent", "Chartres", "Tiron", "Gallardon", "Chateaudun", "Bonneval", "Epernon"], "culture": "old_frankish"}, "Madurai": {"settlements": ["Srivilliputtur", "Madurai", "Tiruparankunram", "Anaimalai", "Kilakarai", "Ramesvaram", "Ramnadhapuram"], "culture": "tamil"}, "Chagai": {"settlements": ["Nushki"], "culture": "baloch"}, "Mahoyadapuram": {"settlements": ["Kaviyur", "Kunjakari", "Kadungallur", "Tripunittura", "Kaladi", "Mahoyadapuram", "Udagai"], "culture": "tamil"}, "Cholamandalam": {"settlements": ["Kannanur", "Nagapattinam", "Tanjavur", "Kumbhakarna", "Srirangam", "Gangaikondacolapuram", "Tiruccirapalli", "Mannargudi", "Citambaram", "Jambukesvara", "Aon Amaravati", "Uraiyur"], "culture": "tamil"}, "Tenkasi": {"settlements": ["Dindigul", "Tirumalapuram", "Tenkasi", "Palayamcottai", "Sankaranayinarkovil", "Aivarmalai"], "culture": "tamil"}, "Qalqut": {"settlements": ["Chaliyam", "Kannur", "Vatakara", "Calicut", "Parappanangadi", "Urakam", "Nediyiruppu"], "culture": "tamil"}, "Manyapura": {"settlements": ["Kikkeri", "Aralaguppe", "Govindanahalli", "Basaralu", "Melukote", "Manyapura", "Turuvekere"], "culture": "kannada"}, "Kanchipuram": {"settlements": ["Kanchipuram", "Koodalur", "Rajagiri", "Alampuravi", "Takkaloma", "Mailapur", "Uttaramerur"], "culture": "tamil"}, "Ile De France": {"settlements": ["Paris", "Melun", "Meaux", "Stdenis", "Montfortlamaury", "Compiegne"], "culture": "old_frankish"}, "Tagadur": {"settlements": ["Tagadur", "Satyamangalam", "Tirukkovalur", "Jinji", "Padaividu", "Siyyamangalam", "Tiruvannamalai"], "culture": "tamil"}, "Uchangidurga": {"settlements": ["Harihar", "Nidugallu", "Uchangidurga", "Hemavati", "Chitradurga", "Parivi", "Sira"], "culture": "kannada"}, "Udayagiri": {"settlements": ["Vallurapura", "Srisailam", "Mahanandi", "Kanipakam", "Sriparvata", "Udayagiri", "Gandikota", "Nandyal"], "culture": "telugu"}, "Vengipura": {"settlements": ["Bandarulanka", "Narasapuram", "Palakollu", "Vengipura", "Eluru", "Dwarakatirumala", "Kondapalli"], "culture": "telugu"}, "Honnore": {"settlements": ["Bhatkal", "Barkur", "Honnore", "Mookambika", "Karwar", "Gokarna"], "culture": "kannada"}, "Thana": {"settlements": ["Janjira", "Bassein", "Thana", "Mahim", "Dabhol", "Kanhagiri", "Chaul"], "culture": "marathi"}, "Daman": {"settlements": ["Bulsar", "Sanjan", "Ramnagar", "Daman", "Nagar Haveli", "Surparaka", "Pardi"], "culture": "gujurati"}, "Navasarika": {"settlements": ["Surat", "Rander", "Navasarika", "Akruresvara", "Tadkeshwar", "Variav", "Dharampur", "Rajpipla", "Bharuch"], "culture": "gujurati"}, "Vizagipatam": {"settlements": ["Simhachalam", "Anakapalle", "Kotipalli", "Bheemunipatnam", "Bavikonda", "Vizagipatam"], "culture": "telugu"}, "Kataka": {"settlements": ["Athgarh", "Sakshigopal", "Katak", "Bhubaneswar", "Dhauli", "Sarala", "Konarak"], "culture": "oriya"}, "Vermandois": {"settlements": ["Montaigu", "Coucy", "Guise", "Crepy", "Laon", "Stquentin", "Signy", "Rethel"], "culture": "old_frankish"}, "Mandavyapura": {"settlements": ["Mandavyapura", "Naddula", "Osian", "Sanderaka", "Mathania", "Siwana", "Ghaneraov"], "culture": "rajput"}, "Karmanta": {"settlements": ["Mainamati", "Udaipur", "Unakoti", "Karmanta"], "culture": "bengali"}, "Kirghiz": {"settlements": ["Abakan"], "culture": "kirghiz"}, "Vadodara": {"settlements": ["Vadodara", "Ankotakka", "Darbhavati", "Vatpatrak", "Kayavarohan", "Nasvadi"], "culture": "gujurati"}, "Bhumilka": {"settlements": ["Bhavnat", "Mangrol", "Shrinagar", "Vamanasthali", "Bhumilka", "Uperkot"], "culture": "gujurati"}, "Valabhi": {"settlements": ["Palatina", "Shatrunjaya", "Valabhi", "Dhandhuka", "Sihor", "Gundigar"], "culture": "gujurati"}, "Dvaraka": {"settlements": ["Gomati", "Bhanvad", "Dvaraka", "Lalpur"], "culture": "gujurati"}, "Mansura": {"settlements": ["Hala", "Mirman", "Mirpur Khas", "Matiari", "Nasarpur", "Mansura", "Nerunkot"], "culture": "sindhi"}, "Bhakkar": {"settlements": ["Sarkara", "Atri", "Bhakkar", "Kalari", "Larkana", "Shikarpur"], "culture": "sindhi"}, "Makran": {"settlements": ["Kiz", "Ormara", "Al Haur", "Kannazbun"], "culture": "baloch"}, "Reims": {"settlements": ["Chatillon", "Roucy", "Provins", "Vertus", "Epernay", "Chalons", "Chateauthierry", "Reims"], "culture": "old_frankish"}, "Banavasi": {"settlements": ["Vankapura", "Ikkeri", "Sringeri", "Kuruvatti", "Lakkundi", "Hangal", "Candragutti", "Vaijayanti", "Balligavi"], "culture": "kannada"}, "Kol": {"settlements": ["Kol", "Nilavati", "Etah", "Soron", "Barauli", "Dor"], "culture": "hindustani"}, "Pratishthana": {"settlements": ["Patkapur", "Harishchandragad", "Bhingar", "Pratishthana", "Ahmednagar", "Chambargonda"], "culture": "marathi"}, "Kalyani": {"settlements": ["Hanakuni", "Kalyani", "Narayanapur", "Ausa", "Umapur"], "culture": "kannada"}, "Kollipake": {"settlements": ["Kollipake", "Karmanghat", "Chilkur Balaji", "Devaryamjal", "Golkonda"], "culture": "telugu"}, "Devagiri": {"settlements": ["Sillod", "Grishneshwar", "Khuldabad", "Vaijapur", "Devagiri"], "culture": "marathi"}, "Naldurg": {"settlements": ["Tuljapur", "Karmala", "Dharaseo", "Paranda", "Naldurg", "Sonnalagi"], "culture": "marathi"}, "Mandapika": {"settlements": ["Mandapika", "Borgarh", "Maheshwar", "Avasgarh", "Bawangaja"], "culture": "hindustani"}, "Dasapura": {"settlements": ["Hinglajgarh", "Taxakeshwar", "Dharmrajeshwar", "Dasapura", "Sondani"], "culture": "rajput"}, "Dhara": {"settlements": ["Dharampuri", "Indore", "Jobat", "Sailana", "Betma", "Depalpur", "Dhara"], "culture": "hindustani"}, "Luxembourg": {"settlements": ["Luxembourg", "Differdange", "Arlon", "Ettelbruck", "Neufchateau", "Bouillon", "Saintvith", "Longwy"], "culture": "old_frankish"}, "Sarangpur": {"settlements": ["Rajgarh", "Ashta", "Jhalawar", "Gagraun", "Sidhhapur", "Sarangpur"], "culture": "hindustani"}, "Laksmanavati": {"settlements": ["Gaur", "Shukla", "Pankak", "Banan", "Puthia", "Malda", "Laksmanavati"], "culture": "bengali"}, "Mudgagiri": {"settlements": ["Kahalgaon", "Campa", "Mudgagiri", "Vikramasila", "Jahnugiri", "Karnagarh", "Lakhisarai"], "culture": "bengali"}, "Kotivarsa": {"settlements": ["Korat", "Jagaddala", "Bangarh", "Devkot", "Siliguri", "Ramavati"], "culture": "bengali"}, "Magadha": {"settlements": ["Rajagrha", "Odantapuri", "Triveni", "Barh", "Pataliputra", "Maner", "Bihar Sharif"], "culture": "bengali"}, "Sripuri": {"settlements": ["Nuapada", "Bagbahara", "Sripuri", "Basna", "Rajiva Lochana"], "culture": "oriya"}, "Kodalaka Mandala": {"settlements": ["Talcher", "Joranda Gadhi", "Bajrakot", "Deogarh", "Karamul", "Kapilash", "Kodalaka", "Dhenkanal"], "culture": "oriya"}, "Balkonda": {"settlements": ["Nirmal", "Balkonda", "Manikdurg", "Mahur", "Dharmapuri", "Basara"], "culture": "telugu"}, "Bidar": {"settlements": ["Tekadee", "Bhatambra", "Kamthana", "Bidar", "Avarwadi", "Jalasangvi", "Bhalki"], "culture": "kannada"}, "Ramagiri": {"settlements": ["Ramagiri", "Nandivardhana", "Mansar", "Pavnar"], "culture": "marathi"}, "Liege": {"settlements": ["Cine", "Namur", "Liege", "Bastogne", "Huy", "Stavelot", "Salm", "Laroche"], "culture": "old_frankish"}, "Rayapura": {"settlements": ["Shivapura", "Shivadurga", "Rayapura", "Nandgram", "Rajim"], "culture": "oriya"}, "Kasmira": {"settlements": ["Shankaracharya", "Parihasapura", "Srinagara", "Padmapura", "Baghsar", "Amaresvara", "Loharakota"], "culture": "panjabi"}, "Kusinagara": {"settlements": ["Chapra", "Kusinagara", "Padrauna", "Pava", "Ramagrama"], "culture": "bengali"}, "Varanasi": {"settlements": ["Bhadohi", "Kashi Vishwanath", "Ballia", "Durga Mandir"], "culture": "hindustani"}, "Chauragarh": {"settlements": ["Chauragarh", "Barman", "Bohani"], "culture": "hindustani"}, "Bandhugadha": {"settlements": ["Bahoriband", "Virateshwar", "Shahdol", "Bandhugadha"], "culture": "hindustani"}, "Jaunpur": {"settlements": ["Tanda", "Gadhipuri", "Haldi", "Dohrighat", "Amethi", "Kerarkot", "Jaunpur"], "culture": "hindustani"}, "Lakhnau": {"settlements": ["Hardoi", "Zaidpur", "Satrikh", "Lakhnau", "Jasnaul"], "culture": "hindustani"}, "Katehar": {"settlements": ["Mandawar", "Bijnor", "Nehtaur", "Gangadvara", "Jageshwar", "Rishikesh"], "culture": "hindustani"}, "Kalpi": {"settlements": ["Kalpi", "Lahar", "Jalaun", "Oirai", "Konch", "Kurara"], "culture": "hindustani"}, "Brabant": {"settlements": ["Grimbergen", "Herstal", "Aarschot", "Mechelen", "Leuven", "Antwerpen", "Brussel", "Lier"], "culture": "old_frankish"}, "Vidisa": {"settlements": ["Bhojpur", "Bijamandal", "Vidisa", "Mangla Devi", "Raisin", "Sironj"], "culture": "hindustani"}, "Kalanjara": {"settlements": ["Devendranagar", "Bhatta", "Jayapura", "Khajuraho", "Panna", "Kalinjar"], "culture": "hindustani"}, "Gwalior": {"settlements": ["Sahastrabahu", "Gwalior", "Sabalgarh", "Vijaypur", "Narwar", "Dabra", "Bateshwar"], "culture": "hindustani"}, "Sambhal": {"settlements": ["Tattandapura", "Amroha", "Ujhani", "Sirsi", "Sambhal", "Bachhraon"], "culture": "hindustani"}, "Godwad": {"settlements": ["Jalor", "Candravati", "Barodiya", "Khudala", "Achalgarh"], "culture": "rajput"}, "Aror": {"settlements": ["Allah Abad", "Chak", "Aror", "Siraj Ji Takri", "Basmak", "Sukkur"], "culture": "sindhi"}, "Medantaka": {"settlements": ["Medantaka", "Sanjoo", "Purnatallakapura", "Phalarddhi"], "culture": "rajput"}, "Kundina": {"settlements": ["Prithiminagar", "Tinsukia", "Kundina", "Sadiya"], "culture": "assamese"}, "Karur": {"settlements": ["Karur", "Askhanda", "Marot", "Chishtian", "Vehari"], "culture": "panjabi"}, "Sakala": {"settlements": ["Bhuttar", "Jammu", "Puran Nagar", "Sakala", "Pasrur", "Vallapura", "Bahu"], "culture": "panjabi"}, "Trier": {"settlements": ["Trier", "Sponheim", "Coblenz", "Wittlich", "Gerolstein", "Laach", "Bitburg", "Andernach"], "culture": "old_frankish"}, "Udabhanda": {"settlements": ["Charsada", "Ohind", "Mankiala", "Attak", "Rawal", "Udabhanda"], "culture": "panjabi"}, "Oshrusana": {"settlements": ["Khujand", "Oshrusana", "Banjikat"], "culture": "sogdian"}, "Ghazna": {"settlements": ["Ghazna", "Khost", "Gardez"], "culture": "afghan"}, "Bost": {"settlements": ["Kandahar", "Sangin"], "culture": "afghan"}, "Kalat": {"settlements": ["Kalat"], "culture": "afghan"}, "Kabul": {"settlements": ["Kabul", "Kapisa", "Kunar", "Kharabat", "Adinapur", "Lampara", "Nagarahara"], "culture": "afghan"}, "Chach": {"settlements": ["Turbat", "Pskent", "Sayram", "Isbijab", "Navekat", "Shymkent", "Chach"], "culture": "sogdian"}, "Kunduz": {"settlements": ["Surkh Kotal", "Aibak"], "culture": "persian"}, "Khuttal": {"settlements": ["Munk", "Rasht", "Vakash", "Halaward", "Qobadhiyan", "Washjird", "Kulob"], "culture": "sogdian"}, "Bamiyan": {"settlements": ["Istalif", "Zakhak", "Chak", "Shar I Gholghola", "Shibar", "Bamiyan"], "culture": "afghan"}, "Koln": {"settlements": ["Koln", "Berg", "Mark", "Bonn", "Saffenburg", "Hochstaden", "Brauweiler", "Dietz"], "culture": "german"}, "Gurjaratra": {"settlements": ["Jhelum", "Hakla", "Tibbi", "Gurjaratra", "Kunjah", "Bhaddar", "Karianwala", "Kharian"], "culture": "panjabi"}, "Bannu": {"settlements": ["Hangu", "Karrak", "Kalabagh", "Dinkot", "Kohat", "Bannu"], "culture": "panjabi"}, "Bhera": {"settlements": ["Bhera", "Rampur", "Phalia", "Girjakh", "Katasraj", "Behak Maken"], "culture": "panjabi"}, "Trigarta": {"settlements": ["Jalandhar", "Kaparthula", "Rahon", "Milwat", "Pathankot", "Sarwmanpur"], "culture": "panjabi"}, "Nagadipa": {"settlements": ["Yapapatuna", "Vallipuram", "Nainativu", "Nallur", "Sukaratittha"], "culture": "tamil"}, "Phiti": {"settlements": ["Anuradhapura", "Mihintale", "Atamasthana", "Mannara", "Mahatittha", "Subhagiri", "Punkhagama"], "culture": "sinhala"}, "Srirangapatna": {"settlements": ["Belapura", "Panasoge", "Periyapatna", "Srirangapatna", "Mysore", "Nanjarayapattana"], "culture": "kannada"}, "Dwarasamudra": {"settlements": ["Koravangala", "Hassan", "Dwarasamudra", "Arasikere", "Sosavur", "Javagallu", "Belur"], "culture": "kannada"}, "Vatapi": {"settlements": ["Vatapi", "Dharwar", "Venugrama", "Bagalkot", "Halasi", "Parasgad", "Aihole"], "culture": "kannada"}, "Penugonda": {"settlements": ["Togarakunta", "Penugonda", "Lepakshi", "Uravakonda", "Suragiri", "Anantapur", "Gurramkonda", "Rayadurgam"], "culture": "kannada"}, "Ossory": {"settlements": ["Callan", "Aghaboe", "Grennan", "Gowran", "Clonmacnoise", "Jerpoint", "Grannagh", "Kilkenny"], "culture": "irish"}, "Gottingen": {"settlements": ["Corvey", "Northeim", "Lippe", "Detmold", "Gottingen", "Eisenach", "Kassel"], "culture": "old_saxon"}, "Kanara": {"settlements": ["Udayavara", "Dharmasthala", "Udupi", "Mangalur", "Kadarika", "Kasargod"], "culture": "kannada"}, "Kongu": {"settlements": ["Tiruppur", "Perur", "Karavur", "Namakkal", "Erode", "Dharapuri", "Sankagiri", "Hemambika", "Sendamangalam"], "culture": "tamil"}, "Kudalasangama": {"settlements": ["Kuknur", "Anegundi", "Bagali", "Dambal", "Kudalasangama", "Koppam", "Musangi"], "culture": "kannada"}, "Idatarainadu": {"settlements": ["Gabburu", "Hemagudda", "Manvi", "Mudgal", "Kammatadurga", "Raichur", "Jaladurga"], "culture": "kannada"}, "Nellore": {"settlements": ["Mutapali", "Tripurantakam", "Nellore", "Kandukura", "Kalahasti", "Gundigapuri", "Addanki"], "culture": "telugu"}, "Narim": {"settlements": ["Kolta"], "culture": "khanty"}, "Taradavadi": {"settlements": ["Pandharpur", "Taradavadi", "Sangole", "Saundatti", "Viyapura", "Hastikundi"], "culture": "kannada"}, "Amaravati": {"settlements": ["Gurazala", "Amaravati", "Dhanyakataka", "Ahobalam", "Macherla", "Kotappakonda", "Vinukonda"], "culture": "telugu"}, "Kambampet": {"settlements": ["Penuballi", "Nelakondapalli", "Kambampet", "Shahpura", "Bhadrachalam", "Madupalli", "Suryapet"], "culture": "telugu"}, "Racakonda": {"settlements": ["Bhuvanagiri", "Yadagirigutta", "Manchal", "Racakonda"], "culture": "telugu"}, "Nassau": {"settlements": ["Katzenelnbogen", "Nassau", "Wetzlar", "Hersfeld", "Falkenstein", "Fulda", "Isenburg", "Marburg"], "culture": "german"}, "Manyakheta": {"settlements": ["Yadavagiri", "Kovilkonda", "Sedam", "Firuzabad", "Manyakheta", "Gulbarga"], "culture": "kannada"}, "Pannagallu": {"settlements": ["Ghanpur", "Nagarkurnool", "Mutudugu", "Pannagallu", "Charakonda"], "culture": "telugu"}, "Lattalura": {"settlements": ["Bir", "Barshi", "Udgir", "Darur", "Tagara", "Lattalura"], "culture": "marathi"}, "Kondana": {"settlements": ["Bhimashankara", "Raigad", "Purandar", "Puna", "Tikona", "Junir", "Rajmachi", "Sudhagad", "Kondana", "Chakan"], "culture": "marathi"}, "Tirunelveli": {"settlements": ["Tirunelveli", "Korkai", "Kalugumalai", "Tiruvalisvaram", "Kayattar", "Kayal"], "culture": "tamil"}, "Dakhina Desa": {"settlements": ["Rayigama", "Jambudoni", "Kalyani2", "Hatthigiripura", "Kotte", "Vapinagara", "Mahiyangana", "Samantakuta"], "culture": "sinhala"}, "Talakad": {"settlements": ["Talakad", "Ummattur", "Veppur", "Nanjangud", "Somanathapura", "Narasamangala", "Kotagiri", "Sivasamudram"], "culture": "kannada"}, "Nandagiri": {"settlements": ["Nandagiri", "Kurudumale", "Avani", "Kuvalala", "Kundani", "Mulavagil", "Nangali"], "culture": "kannada"}, "Alampur": {"settlements": ["Kampili", "Ittagi", "Vijayanagara", "Gooty", "Hampi", "Adavani", "Alampur"], "culture": "kannada"}, "Potapi": {"settlements": ["Potapi", "Melpadi", "Tirupati", "Virincipuram", "Kalahasti", "Kaveripattinam"], "culture": "telugu"}, "Leiningen": {"settlements": ["Lorsch", "Hardenburg", "Durkheim", "Leiningen", "Battenberg", "Ungstein", "Pfeffingen", "Heidelberg"], "culture": "german"}, "Goa": {"settlements": ["Kapardikadvipa", "Chitrakul", "Gopakapattana", "Gheria", "Mathagram", "Chandrapur"], "culture": "marathi"}, "Vijayawada": {"settlements": ["Guntur", "Vijayawada", "Peddapalli", "Masula", "Kondavidu", "Chebrolu"], "culture": "telugu"}, "Rajamahendravaram": {"settlements": ["Barsoor", "Dantewada", "Rajamahendravaram", "Kirandul", "Kuwakonda", "Bhadrachalam"], "culture": "telugu"}, "Ishim": {"settlements": ["Esil"], "culture": "cuman"}, "Kalinganagar": {"settlements": ["Mandasa", "Kalingapattanam", "Kalinganagara", "Srikakulam", "Srikurmam"], "culture": "oriya"}, "Puri": {"settlements": ["Ganjam", "Puri", "Jaugada", "Buguda", "Aska", "Gopalpur", "Taratarini"], "culture": "oriya"}, "Nandapur": {"settlements": ["Nandapur", "Jeypore", "Junagarh", "Koraput", "Dharamgarh"], "culture": "oriya"}, "Cakrakuta": {"settlements": ["Kanker", "Jagdalpur", "Cakrakuta"], "culture": "oriya"}, "Swetaka Mandala": {"settlements": ["Umerkote", "Swetakapura", "Badakhemundi", "Rayagada"], "culture": "oriya"}, "Khinjali Mandala": {"settlements": ["Khinjali", "Nilamadhav", "Nayagarh", "Baramba"], "culture": "oriya"}, "Mainz": {"settlements": ["Weilburg", "Ingelheim", "Mainz", "Dornburg", "Mannheim", "Frankfurt", "Eppstein", "Hanau"], "culture": "old_frankish"}, "Suvarnapura": {"settlements": ["Agalpur", "Suvarnapura", "Yajatinagara", "Bargarh", "Patna", "Vinitapura", "Kalahandi"], "culture": "oriya"}, "Viraja": {"settlements": ["Bhadrak", "Viraja", "Soro", "Raibania", "Anandpur", "Baleshvara", "Mahavinayak"], "culture": "oriya"}, "Midnapore": {"settlements": ["Dantan", "Hilji", "Moghalmari", "Kashipur", "Midnapore"], "culture": "oriya"}, "Saptagrama": {"settlements": ["Bansberia", "Pandua", "Tribeni", "Shantipur", "Saptagrama", "Mahanad", "Chinsura"], "culture": "bengali"}, "Damin I Koh": {"settlements": ["Deogarh2", "Shikarji"], "culture": "bengali"}, "Tamralipti": {"settlements": ["Sagardwip", "Chandraketugarh", "Jahajghata", "Tamralipti", "Ishwaripur"], "culture": "bengali"}, "Candradvipa": {"settlements": ["Sathkira", "Bagerhat", "Khulna", "Bakarganj", "Candradvipa"], "culture": "bengali"}, "Rajrappa": {"settlements": ["Kenduli"], "culture": "bengali"}, "Mallabhum": {"settlements": ["Garhbeta", "Baghmundi", "Bishnupur", "Chandrakona", "Dihar", "Mandaran"], "culture": "bengali"}, "Vijayapura": {"settlements": ["Patuli", "Dishergarh", "Churulia", "Kalna", "Begunia", "Vijayapura"], "culture": "bengali"}, "Pfalz": {"settlements": ["Kaiserslautern", "Trifels", "Stahleck", "Worms", "Hagenau", "Zweibrucken", "Saarbrucken", "Speyer"], "culture": "german"}, "Kumara Mandala": {"settlements": ["Fathabad", "Kumarakhali", "Ekdala", "Katasgarh"], "culture": "bengali"}, "Jharkand": {"settlements": ["Kandra", "Ambikapur", "Koriya"], "culture": "bengali"}, "Radha": {"settlements": ["Lakhnor", "Ichhai Ghoshgarh", "Rampur Boalia", "Gopbhum", "Kalyaneshwari", "Katwa", "Hirapur"], "culture": "bengali"}, "Gauda": {"settlements": ["Raktamrittika", "Agmahl", "Adinatha Mandir", "Karnasubarna", "Tarapith", "Teliagarhi"], "culture": "bengali"}, "Kamatapur": {"settlements": ["Bhitagarh", "Nalrajar Garh", "Japyesvara", "Kamatapur", "Mainaguri"], "culture": "assamese"}, "Srihatta": {"settlements": ["Habiganj", "Egarosindur", "Jangalbari", "Srihatta", "Nasirabad"], "culture": "assamese"}, "Goalpara": {"settlements": ["Kamakhya", "Dhubri", "Sri Surya Pahar", "Goalpara"], "culture": "assamese"}, "Khijjingakota": {"settlements": ["Bahalda", "Asanapat", "Baripada", "Kirianagar", "Sitabhinji", "Khijjinga", "Ghatagaon"], "culture": "oriya"}, "Munda": {"settlements": ["Marang Buru", "Chutia", "Ratu"], "culture": "oriya"}, "Sambalpur": {"settlements": ["Rajgangpur", "Bimaleswar", "Sambalpur", "Maneswar", "Ranipur", "Samaleswari"], "culture": "oriya"}, "Baden": {"settlements": ["Karlsruhe", "Pforzheim", "Rastatt", "Neuhausen", "Baden", "Durlach", "Calw", "Wimpfen"], "culture": "german"}, "Ayodhya": {"settlements": ["Ayodhya", "Nageshwarnath", "Faizabad", "Hanuman Garhi", "Ramkot", "Sarairasi"], "culture": "hindustani"}, "Sasaram": {"settlements": ["Mundeshwari", "Jaund", "Horilnagar", "Arrah", "Sasaram"], "culture": "bengali"}, "Barasuru": {"settlements": ["Dantewada", "Barasuru", "Barsoor"], "culture": "oriya"}, "Nilagiri": {"settlements": ["Panagallu", "Maheshwaram", "Vadapally", "Avulagadda", "Devarakonda", "Nilagiri"], "culture": "telugu"}, "Vairagara": {"settlements": ["Bhandugara", "Cikamburika", "Vairagara", "Gondia"], "culture": "marathi"}, "Vemulavada": {"settlements": ["Kaleshwaram", "Indur", "Vemulavada", "Kaulas", "Ramgarh", "Potali"], "culture": "telugu"}, "Orangallu": {"settlements": ["Ghanpur", "Warangal", "Anumakonda", "Kothakonda", "Bhadrakali", "Palampet", "Molangoor"], "culture": "telugu"}, "Medak": {"settlements": ["Domakonda", "Kohir", "Medak", "Ananthagiri", "Mardi"], "culture": "telugu"}, "Nanded": {"settlements": ["Nanded", "Shelgaon", "Pathri", "Qandhar", "Aurad", "Parbhani"], "culture": "marathi"}, "Vatsagulma": {"settlements": ["Lonar", "Satgaon", "Vatsagulma", "Jalna", "Manora", "Nandura"], "culture": "marathi"}, "Nordgau": {"settlements": ["Strassburg", "Egisheim", "Erstein", "Brumath", "Molsheim", "Lauterburg", "Schlettstadt", "Selz"], "culture": "old_frankish"}, "Nasikya": {"settlements": ["Seunapura", "Ratangad", "Saptashrungi", "Patta", "Nasikya", "Igatpuri", "Tryambaka"], "culture": "marathi"}, "Parnakheta": {"settlements": ["Parnakheta", "Karanja", "Buldhana", "Ambadapura", "Mahkar", "Akola"], "culture": "marathi"}, "Thalner": {"settlements": ["Thalner", "Bhamer", "Laling", "Jhodga", "Amalner", "Balasane", "Sindkheda"], "culture": "marathi"}, "Burhanpur": {"settlements": ["Yawal", "Vaghli", "Burhanpur", "Erandol", "Changdev"], "culture": "marathi"}, "Nandurbar": {"settlements": ["Songarh", "Nandurbar", "Malegaon", "Mayuragiri", "Sultanpur", "Bhambhagiri", "Chandor"], "culture": "marathi"}, "Sagar": {"settlements": ["Pattadakal", "Bagavadi", "Talikota", "Sagar", "Bagalkot", "Sorapur"], "culture": "kannada"}, "Somnath": {"settlements": ["Diu", "Delvada", "Veraval", "Vejalkot", "Moherak", "Somnath", "Kanjetar"], "culture": "gujurati"}, "Vardhamana": {"settlements": ["Ranpur", "Halvad", "Amarvalli", "Vardhamana"], "culture": "gujurati"}, "Dhamalpur": {"settlements": ["Lakhota", "Halvad", "Dhamalpur", "Khasta", "Morvi"], "culture": "gujurati"}, "Canda": {"settlements": ["Canda", "Nagbhid", "Ballarpur", "Rajura", "Gadchiroli"], "culture": "telugu"}, "Lorraine": {"settlements": ["Charpeigne", "Mortagnedevosges", "Epinal", "Luneville", "Sarrebourg", "Toul", "Nancy", "Saintavoid"], "culture": "old_frankish"}, "Kiranapura": {"settlements": ["Lanji", "Kiranapura", "Balaghat"], "culture": "marathi"}, "Tripuri": {"settlements": ["Garha", "Tripuri", "Mandla"], "culture": "hindustani"}, "Ratanpur": {"settlements": ["Ratanpur", "Saravpur", "Pali", "Savarinarayana"], "culture": "hindustani"}, "Turgay": {"settlements": ["Zhailyk", "Karakal"], "culture": "pecheneg"}, "Damoh": {"settlements": ["Nohta", "Dhamoni", "Singrampur", "Narsinghgarh", "Damoh"], "culture": "hindustani"}, "Zaranj": {"settlements": ["Zaranj", "Zahak", "Zabol"], "culture": "afghan"}, "Gaya": {"settlements": ["Nawada", "Bodh Gaya", "Sherghati", "Elahabad", "Nalanda"], "culture": "bengali"}, "Tummana": {"settlements": ["Amarkantak", "Manendragarh", "Tummana"], "culture": "hindustani"}, "Gurgi": {"settlements": ["Satna", "Gurgi", "Chandrehi", "Bathgahora"], "culture": "hindustani"}, "Rohana": {"settlements": ["Devanagara", "Mahagama", "Dighavapi", "Kajaragama", "Buduruvagala", "Gampala", "Mahanagakula"], "culture": "sinhala"}, "Metz": {"settlements": ["Bouzonville", "Joudreville", "Thionville", "Metz", "Saintjulien", "Marslatour", "Audunleroman", "Briey"], "culture": "old_frankish"}, "Gojjam": {"settlements": ["Gojjam", "Mankorar", "Yejube", "Godana Mikael", "Yegeleka", "Baremma", "Eliyas"], "culture": "ethiopian"}, "Chunar": {"settlements": ["Chunar", "Vindhyachal", "Kantit"], "culture": "hindustani"}, "Dotawo": {"settlements": ["Premnis", "Faras", "Jebeladda", "Buhen", "Ballana", "Qasribrim", "Dotawo"], "culture": "nubian"}, "Asni": {"settlements": ["Bhitargaon", "Asni2", "Bindki", "Kora", "Shivrajpur", "Musanagar", "Khaga"], "culture": "hindustani"}, "Bharauli": {"settlements": ["Manikpur", "Lalganj", "Bhadri", "Bharauli"], "culture": "hindustani"}, "Acalapura": {"settlements": ["Yavatmal", "Bhojapur", "Narnala", "Acalapura", "Kalam", "Amravati"], "culture": "marathi"}, "Kherla": {"settlements": ["Pachmarhi", "Anjangaon", "Kherla", "Gawilghar"], "culture": "marathi"}, "Asirgarh": {"settlements": ["Sanawad", "Mandleshwar", "Khargone", "Asirgarh", "Khandwa"], "culture": "marathi"}, "Ujjayini": {"settlements": ["Ujjayini", "Mehidpur", "Akodia", "Maksi", "Dewas", "Agar"], "culture": "hindustani"}, "Dadhipadra": {"settlements": ["Jawad", "Godhra", "Dadhipadra", "Pavagadh", "Champaner", "Kalika Mata"], "culture": "rajput"}, "Verdun": {"settlements": [], "culture": "old_frankish"}, "Khetaka": {"settlements": ["Bhadran", "Khambhat", "Khetaka", "Tarapur", "Ashaval", "Dholka", "Sanand", "Nadiad"], "culture": "gujurati"}, "Mohadavasaka": {"settlements": ["Shamlaji", "Lunawada", "Unjha", "Danta", "Jhalod", "Mohadavasaka"], "culture": "rajput"}, "Sarasvata Mandala": {"settlements": ["Shertha", "Kamboika", "Kheralu", "Idar", "Siddhapura", "Anahilapataka", "Modhera"], "culture": "gujurati"}, "Satyapura": {"settlements": ["Kiradu", "Juna Barmer", "Kiratakupa", "Satyapura"], "culture": "rajput"}, "Kutch": {"settlements": ["Bhuj", "Kanthakota", "Dhaneti", "Anjar"], "culture": "gujurati"}, "Dimapur": {"settlements": ["Oddiyana", "Herombial", "Dimapur", "Maibong"], "culture": "assamese"}, "Debul": {"settlements": ["Banbhore", "Kolachi", "Debul", "Shahbandar", "Lari Bandar", "Thatta", "Makli", "Landhi"], "culture": "sindhi"}, "Chanderi": {"settlements": ["Chanderi", "Garh Kundar", "Jarai Ka Math", "Aharji", "Khurai", "Jhansi", "Luacchagiri"], "culture": "hindustani"}, "Candhoba": {"settlements": ["Candhoba", "Sipri", "Guna", "Kadwaya"], "culture": "hindustani"}, "Thomond": {"settlements": ["Ennis", "Killaloe", "Kilfenora", "Limerick", "Adare", "Bunratty", "Askeaton", "Emly"], "culture": "irish"}, "Troyes": {"settlements": ["Clairvaux", "Troyes", "Brienne", "Chacenay", "Chaumont", "Langres"], "culture": "old_frankish"}, "Kota": {"settlements": ["Taragarh", "Kota", "Ramgarh", "Bundi", "Koshvardhan"], "culture": "rajput"}, "Mahoba": {"settlements": ["Chitrakuta", "Mahoba", "Ajaigarh", "Rath", "Hamirpur"], "culture": "hindustani"}, "Chitrakut": {"settlements": ["Baroli", "Nagari", "Mandalgarh", "Rampura", "Bhainsrorgarh", "Chitrakut"], "culture": "rajput"}, "Ranikot": {"settlements": ["Ranikot", "Sharusan", "Khudabad", "Jandar", "Paat", "Manhabari"], "culture": "sindhi"}, "Ludrava": {"settlements": ["Lanela", "Pali", "Ludrava", "Jaisalmer", "Phalavardhika"], "culture": "rajput"}, "Tura": {"settlements": ["Almaty"], "culture": "kirghiz"}, "Sens": {"settlements": ["Montereau", "Villeneuveleroi", "Nogentsurseine", "Montargis", "Chateaulandon", "Joigny", "Sens", "Nemours"], "culture": "old_frankish"}, "Samatata": {"settlements": ["Chatigama", "Candranatha", "Devaparvata"], "culture": "bengali"}, "Bikrampur": {"settlements": ["Sutrapur", "Loricol", "Hajiganj", "Bikrampur", "Shakhari Bazar", "Dhakeshwari Jatiya Mandir"], "culture": "bengali"}, "Auxerre": {"settlements": ["Pontigny", "Druyes", "Crisenon", "Tonnerre", "Cravant", "Mailly", "Auxerre", "Stsauveurenpuisaye"], "culture": "old_frankish"}, "Aydhab": {"settlements": ["Aydhab", "Troglodytica", "Zabargad", "Halayeb", "Elba", "Marsaalam", "Shalateen"], "culture": "nubian"}, "Kamarupanagara": {"settlements": ["Pragyotisapura", "Kamarupanagara", "Hajo", "Dariyaon", "Madan Kamdev", "Manikuta", "Durjaya"], "culture": "assamese"}, "Nobatia": {"settlements": ["Abri", "Akasha", "Nubia", "Soleb", "Delgo", "Semna", "Wawa"], "culture": "nubian"}, "Nabadwipa": {"settlements": ["Nabadwipa", "Bidhyanandikathi", "Pancharatna", "Krishnagar", "Madhyadwip", "Godrumdwip", "Ritudwip"], "culture": "bengali"}, "Suvarnagram": {"settlements": ["Satkhira", "Suvarnagram", "Narikella", "Bokainagar", "Susanga"], "culture": "assamese"}, "Madhupur": {"settlements": ["Pabna", "Madhupur", "Bogra", "Baghabarihat"], "culture": "bengali"}, "Napata": {"settlements": ["Keheilli", "Karima", "Marawi", "Napata", "Kanisah", "Korti"], "culture": "nubian"}, "Rothas": {"settlements": ["Rohtas", "Palamau", "Rohtasan", "Rohtasgarh", "Betla"], "culture": "bengali"}, "Prayaga": {"settlements": ["Prayaga", "Daraganj", "Chowk", "Alopibagh", "Kausambi", "Kara", "Dariyabad"], "culture": "hindustani"}, "Ket": {"settlements": ["Sochur"], "culture": "kirghiz"}, "Saintois": {"settlements": ["Saintois", "Ornois", "Dompaire", "Saulnois", "Brixey", "Ivios", "Vaudemont", "Sorcystmartin"], "culture": "old_frankish"}, "Suakin": {"settlements": ["Derkin", "Salum", "Komelshokafa", "Tisiamti", "Dubarua", "Taiwi", "Sawakin"], "culture": "nubian"}, "Sonda": {"settlements": ["Karoonjar", "Amarkot", "Matli", "Mamhal", "Sonda", "Nagarparkar", "Badin"], "culture": "sindhi"}, "Trinkitat": {"settlements": ["Derri", "Trinkitat", "Teb", "Mukden", "Kwababa", "Tokar", "Farata"], "culture": "nubian"}, "Siwistan": {"settlements": ["Siwistan", "Vicalapura", "Guja", "Mir Rukan", "Dahlilah"], "culture": "sindhi"}, "Alodia": {"settlements": ["Malaka", "Omdurman", "Omjerky", "Wawissi", "Barah", "Alwa"], "culture": "nubian"}, "Kosti": {"settlements": ["Lagawa", "Umm Ruwaba", "Dalang", "Kosti", "Kaduqli", "Abbeit"], "culture": "nubian"}, "Vijnot": {"settlements": ["Kishangarh", "Vijnot", "Ghotki", "Bhatiya"], "culture": "sindhi"}, "Uch": {"settlements": ["Chachran", "Chaudari", "Sitpur", "Derawar", "Mithankot", "Uch"], "culture": "panjabi"}, "Multan": {"settlements": ["Mulasthana", "Prahladpuri", "Makhdum Rashid", "Alipur", "Multan", "Kabirwala", "Tulamba"], "culture": "panjabi"}, "Rajanpur": {"settlements": ["Harrand", "Rojhan", "Dajal", "Rajanpur", "Adhiwala"], "culture": "sindhi"}, "Sundgau": {"settlements": ["Landser", "Ferette", "Mulhouse", "Altkirch", "Ensisheim", "Thann", "Murbach", "Kolmar"], "culture": "old_frankish"}, "Karor": {"settlements": ["Shadia", "Mankera", "Karor", "Wan Bhachran"], "culture": "panjabi"}, "Nandana": {"settlements": ["Simhapura", "Tulaja", "Khushab", "Khewra", "Nandana", "Hund", "Lund2"], "culture": "panjabi"}, "Purushapura": {"settlements": ["Purushapura", "Mardan", "Bajaur", "Nowshera", "Shergarh", "Shah Ji Dheri", "Ali Masjid"], "culture": "panjabi"}, "Massawa": {"settlements": ["Cheren", "Dahano", "Matara", "Adulis", "Massawa", "Sembel", "Qohaito"], "culture": "nubian"}, "Zeila": {"settlements": ["Zeila", "Amud", "Hargeysa", "Lughaya", "Dilla", "Jijiga", "Borama"], "culture": "somali"}, "Medapata": {"settlements": ["Aghata", "Nagahrada", "Sas Bahu", "Rishabhdeo", "Eklingji", "Bagar", "Jagadamba"], "culture": "rajput"}, "Ajayameru": {"settlements": ["Dhanop", "Pushkar", "Lawah", "Taragarh", "Shakambhari", "Nareli", "Ajayameru"], "culture": "rajput"}, "Vikramapura": {"settlements": ["Vikramapura", "Kolayat", "Shekhsar", "Bhurupal", "Bhandasar"], "culture": "rajput"}, "Besancon": {"settlements": ["Beaucourt", "Vesoul", "Montbeliard", "Besancon", "Valdahon", "Morteau", "Belfort", "Maiche"], "culture": "old_frankish"}, "Reni": {"settlements": ["Mandir", "Reni", "Bidasar", "Dadrewa", "Sidhmukh"], "culture": "rajput"}, "Nagchu": {"settlements": ["Nagchu"], "culture": "sumpa"}, "Sarasvati": {"settlements": ["Bhatnir", "Bhadra", "Tarain", "Sarasvati"], "culture": "hindustani"}, "Vairata": {"settlements": ["Amer", "Dhosi", "Jeenmata", "Harshnath", "Khatushyam", "Vairata", "Sanganer"], "culture": "rajput"}, "Nagauda": {"settlements": ["Nagauda", "Ladnun", "Kuchaman", "Mundwa", "Ladnu", "Ahichhatrapur", "Makrana"], "culture": "rajput"}, "Ranthambore": {"settlements": ["Gangapur", "Sheopur", "Tonkra", "Mandrael", "Utgir", "Ranthambore"], "culture": "rajput"}, "Kanyakubja": {"settlements": ["Kampil", "Bithor", "Swargdwari", "Jai Chandra", "Etawah", "Kanyakubja", "Jajmau"], "culture": "hindustani"}, "Sripatha": {"settlements": ["Sripatha", "Abanhagari", "Dhavalapuri", "Dholeshwar Mahadev", "Bayana"], "culture": "hindustani"}, "Vodamayutja": {"settlements": ["Vodamayutja", "Tilokpur", "Bareily", "Sheikhupur", "Anwala", "Ahichatra"], "culture": "hindustani"}, "Mathura": {"settlements": ["Agra", "Govardhan", "Mankameshwar", "Dhanauli", "Mathura", "Vrindavan", "Khanwa"], "culture": "hindustani"}, "Dijon": {"settlements": ["Beaune", "Vezelay", "Citeaux", "Dijon", "Avallon", "Autun", "Noyers", "Semur"], "culture": "old_frankish"}, "Maldives": {"settlements": ["Dhanbidhoo", "Gan", "Mundoo", "Mahal", "Isdhoo", "Salliballu", "Fuvahmulah"], "culture": "tamil"}, "Shorkot": {"settlements": ["Bhirr", "Chandrod", "Shorkot", "Kamalia", "Jhang", "Rabwah", "Bhawana"], "culture": "panjabi"}, "Lahur": {"settlements": ["Lahur", "Mehdiabad", "Chunian", "Kasur", "Samnabad", "Data Darbar", "Sangla"], "culture": "panjabi"}, "Dipalpur": {"settlements": ["Dipalpur", "Abohar", "Satghara", "Chichawatni", "Ajodhan", "Pancapura"], "culture": "panjabi"}, "Tribandapura": {"settlements": ["Jaintpuri", "Kartikeya", "Tribandapura", "Sunam", "Amin"], "culture": "hindustani"}, "Delhi": {"settlements": ["Lalkot", "Mehrauli", "Siri", "Jahanpanah", "Dhilika", "Narela", "Indraprastha"], "culture": "hindustani"}, "Hisar": {"settlements": ["Kalanaur", "Agroha", "Asika", "Asigarh", "Surajkund", "Hisar", "Rohtak"], "culture": "hindustani"}, "Sthanisvara": {"settlements": ["Karnal", "Sthanisvara", "Samana", "Shakumbhri Devi", "Panipat", "Saharanpur", "Sirhind"], "culture": "hindustani"}, "Hastinapura": {"settlements": ["Hastinapura", "Pankot", "Baran", "Pandeshwar", "Mirath", "Hapur", "Indrasthana"], "culture": "hindustani"}, "Socotra": {"settlements": ["Siqirah", "Asma", "Tamrida", "Qualnsiyah", "Qashiu", "Qadub", "Steroh"], "culture": "bedouin_arabic"}, "Nevers": {"settlements": ["Nevers", "Courtenay", "Donzy", "Lacharite", "Cosne", "Vandenesse", "Chateauchinon", "Clamecy"], "culture": "old_frankish"}, "Armail": {"settlements": ["Yusli", "Kambali", "Armail", "Hingula"], "culture": "sindhi"}, "Quzdar": {"settlements": ["Quzdar", "Bodein"], "culture": "sindhi"}, "Kandail": {"settlements": ["Dadu", "Jhal", "Kandail"], "culture": "sindhi"}, "Assab": {"settlements": ["Mergebla", "Debaysima", "Rehayto", "Gehare", "Assab", "Agurto", "Manda"], "culture": "ethiopian"}, "Sibi": {"settlements": ["Walishtan", "Mastanj", "Dadhar", "Sibi"], "culture": "sindhi"}, "Kafirkot": {"settlements": ["Malot", "Dera Ghazi Khan", "Maniot", "Bilot", "Kafirkot"], "culture": "panjabi"}, "Wana": {"settlements": ["Bori"], "culture": "afghan"}, "Maymana": {"settlements": ["Gurziwan", "Maymana", "Darzab", "Bilcheragh", "Almar"], "culture": "persian"}, "Urgench": {"settlements": ["Urgench", "Kyrkmolla", "Kizil Agir"], "culture": "persian"}, "Asayita": {"settlements": ["Serdo", "Asayita", "Lofefle", "Jewaha", "Afambo", "Tendaho", "Dedai"], "culture": "ethiopian"}, "Orleans": {"settlements": ["Fleury", "Lepuiset", "Sully", "Gien", "Jargeau", "Meung", "Janville", "Orleans"], "culture": "old_frankish"}, "Semien": {"settlements": ["Dabat", "Belesa", "Ambaras", "Ciarveta", "Amja Lebes", "Debark", "Oivela Mariam"], "culture": "ethiopian"}, "Pundravardhana": {"settlements": ["Somapura Mahavihara", "Khulnar Dhap", "Bhimer Jangal", "Ghoraghat", "Totaram Panditer Dhap", "Pundravardhana", "Mahasthangarh"], "culture": "bengali"}, "Bourges": {"settlements": ["Sancerre", "Deols", "Mehun", "Vierzon", "Chateauroux", "Bourges", "Stsatur", "Issoudun"], "culture": "old_frankish"}, "Desmond": {"settlements": ["Cork", "Cloyne", "Ross", "Ardfert", "Youghal", "Dunasead", "Fermoy"], "culture": "irish"}, "Tourraine": {"settlements": ["Loches", "Tours", "Chinon", "Beaulieu", "Langeais", "Montbazon", "Amboise", "Fierbois"], "culture": "old_frankish"}, "Anxi": {"settlements": ["Anxi", "Guazhou"], "culture": "han"}, "Poitiers": {"settlements": ["Loudun", "Poitiers", "Parthenay", "Chatellerault", "Stsavin", "Mirebeau", "Moncontour"], "culture": "occitan"}, "Venadu": {"settlements": ["Anantasayanam", "Kollam", "Nagercoil", "Kandalur", "Vizhinjam", "Kanya Kumari"], "culture": "tamil"}, "Kotthasara": {"settlements": ["Trincomalee", "Girikandaka", "Sigiriya", "Gokanna", "Vatagiri", "Pulatthinagara", "Madakalapuva"], "culture": "sinhala"}, "Pithapuram": {"settlements": ["Samalkota", "Somarama", "Pithapuram", "Draksharama", "Kakinada", "Mandapeta"], "culture": "telugu"}, "Kolhapur": {"settlements": ["Manapura", "Kolhapur", "Satara", "Miraj", "Pranala", "Karahataka", "Kurundaka"], "culture": "marathi"}, "Wag": {"settlements": ["Lashwa", "Liktaba", "Sacca", "Zumbo", "Sekota", "Tsaicha", "Indeher Giba"], "culture": "ethiopian"}, "Haruppeswara": {"settlements": ["Numaligarh", "Dibarumukh", "Haruppeswara", "Charaideo"], "culture": "assamese"}, "Mithila": {"settlements": ["Darbhanga", "Hajipur", "Saligrama", "Yavamajjhaka", "Sugauna", "Mithila", "Siwan"], "culture": "bengali"}, "Thouars": {"settlements": ["Fontenay", "Mauleon", "Larochelle", "Bressuire", "Chatelaillon", "Lucon", "Thouars", "Olonne"], "culture": "old_frankish"}, "Simaramapura": {"settlements": ["Bettiah", "Kesaria", "Bhaktagrama", "Vaid", "Pattana", "Simaramapura"], "culture": "bengali"}, "Sravasti": {"settlements": ["Barohiya", "Jetavana", "Sravasti", "Gorakhpur", "Maghar", "Gorakhnath Math", "Amorha"], "culture": "hindustani"}, "Naimisa": {"settlements": ["Lakhimpur", "Sitapur", "Misrikh", "Gonda", "Naimisa", "Bahraich"], "culture": "hindustani"}, "Fergana": {"settlements": ["Rishton", "Uzkand", "Marginan", "Aval", "Nadaq", "Osh", "Andijan"], "culture": "sogdian"}, "Chuy": {"settlements": ["Almatu", "Bishkek"], "culture": "karluk"}, "Ili": {"settlements": ["Koktal", "Kulja"], "culture": "karluk"}, "Zhetysu": {"settlements": ["Taldykorgan", "Karatal"], "culture": "karluk"}, "Urzhar": {"settlements": ["Ayagoz", "Akzhar"], "culture": "kirghiz"}, "Damot": {"settlements": ["Yirga Chefe", "Muger", "Teltele", "Fasha", "Awasa", "Zima", "Malbarde"], "culture": "ethiopian"}, "Begemder": {"settlements": ["Danya", "Maryamu", "Filakit", "Awariya", "Bete Yohanis", "Gereger", "Chekerefta"], "culture": "ethiopian"}, "Saintonge": {"settlements": ["Tonnay", "Stjeandangely", "Villeneuve", "Taillebourg", "Saintes", "Montguyon", "Aulnay", "Royan"], "culture": "occitan"}, "Kipchak": {"settlements": ["Kipchak", "Zhailma"], "culture": "pecheneg"}, "Otrar": {"settlements": ["Shoshkakoi", "Shaulder"], "culture": "karluk"}, "Karluk": {"settlements": ["Ulug Ok"], "culture": "karluk"}, "Kazakh": {"settlements": ["Zhairem", "Kengir"], "culture": "pecheneg"}, "Balkhash": {"settlements": ["Gulshat", "Shashubay"], "culture": "cuman"}, "Kimak": {"settlements": ["Atasu", "Tengiz"], "culture": "cuman"}, "Lakomelza": {"settlements": ["Dessye", "Tigaja", "Metene", "Ziya", "Kembolcha", "Habru", "Cherkwa"], "culture": "ethiopian"}, "Tigrinya": {"settlements": ["Bilamba", "Golonco", "Tigrinya", "Adenna", "Adi Ramets", "Zagamat", "Amba Maderiya"], "culture": "ethiopian"}, "Yarkand": {"settlements": ["Yarkand", "Yecheng"], "culture": "saka"}, "Kashgar": {"settlements": ["Kashgar", "Xiuxun"], "culture": "saka"}, "Lusignan": {"settlements": ["Charroux", "Niort", "Civray", "Lusignan", "Stmaixent", "Maillezais", "Melle", "Confolens"], "culture": "occitan"}, "Khotan": {"settlements": ["Jiandu", "Khotan", "Jingjue"], "culture": "saka"}, "Cherchen": {"settlements": ["Endere", "Cherchen"], "culture": "tocharian"}, "Charkliq": {"settlements": ["Charkliq", "Miran"], "culture": "tocharian"}, "Karashar": {"settlements": ["Karashar", "Tiemenguan", "Korla", "Weixu"], "culture": "tocharian"}, "Kucha": {"settlements": ["Subashi", "Kumtura", "Kizil", "Kucha"], "culture": "tocharian"}, "Aksu": {"settlements": ["Aksu Mongolia", "Wensu"], "culture": "tocharian"}, "Kara Khoja": {"settlements": ["Turfan", "Kara Khoja", "Astana", "Jiaohe", "Bezeklik"], "culture": "tocharian"}, "Loulan": {"settlements": ["Kroran", "Lopnor", "Loulan"], "culture": "tocharian"}, "Dunhuang": {"settlements": ["Dunhuang", "Fangpan", "Yueyaquan", "Mogao", "Yumenquan"], "culture": "han"}, "Luntai": {"settlements": ["Luntai", "Fukang", "Changji"], "culture": "tocharian"}, "La Marche": {"settlements": ["Bellac", "Gueret", "Aubusson", "Lasouterraine", "Jouillat", "Crozant", "Boussac", "Bourganeuf"], "culture": "occitan"}, "Kumul": {"settlements": ["Kumul", "Piqan"], "culture": "tocharian"}, "Altay": {"settlements": [], "culture": "uyghur"}, "Beshbaliq": {"settlements": ["Mori", "Dunkheger", "Gucheng", "Jiangjunmiao", "Hou Pulei", "Yulishi"], "culture": "uyghur"}, "Aj Bogd": {"settlements": [], "culture": "uyghur"}, "Muztau": {"settlements": [], "culture": "uyghur"}, "Tsagaannuur": {"settlements": [], "culture": "uyghur"}, "Ikh Bogd": {"settlements": [], "culture": "uyghur"}, "Kara Khorum": {"settlements": ["Noin Ula"], "culture": "uyghur"}, "Khangai": {"settlements": [], "culture": "uyghur"}, "Kyzyl": {"settlements": [], "culture": "uyghur"}, "Bourbon": {"settlements": ["Murat", "Souvigny", "Moulins", "Montpensier", "Vichy", "Bourbon", "Lancy"], "culture": "old_frankish"}, "Baygal": {"settlements": [], "culture": "uyghur"}, "Otuken": {"settlements": [], "culture": "uyghur"}, "Gorgol": {"settlements": [], "culture": "kirghiz"}, "Erchis": {"settlements": ["Korya"], "culture": "kirghiz"}, "Gilgit": {"settlements": ["Danyor", "Gilgit", "Chitral"], "culture": "panjabi"}, "Tashkurgan": {"settlements": ["Jianggala", "Tashkurgan"], "culture": "saka"}, "Skardu": {"settlements": ["Huldi", "Skardu"], "culture": "zhangzhung"}, "Diskit": {"settlements": ["Thirit", "Diskit"], "culture": "zhangzhung"}, "Leh": {"settlements": ["Keylong", "Leh", "Gya", "Shey"], "culture": "zhangzhung"}, "Kangra": {"settlements": ["Nurpur", "Kangra", "Shimla"], "culture": "panjabi"}, "Limousin": {"settlements": ["Chalus", "Limoges", "Ventadour", "Rochechouart", "Thiviers", "Turenne", "Stleonard", "Comborn"], "culture": "occitan"}, "Garhwal": {"settlements": ["Srinagar", "Badrinath", "Devalghar"], "culture": "hindustani"}, "Kurmanchal": {"settlements": ["Kartikeyapura", "Askot Kurmanchal", "Katarmal"], "culture": "hindustani"}, "Jumla": {"settlements": ["Simikot", "Jumla"], "culture": "nepali"}, "Doti": {"settlements": ["Dullu", "Dailekh"], "culture": "nepali"}, "Lumbini": {"settlements": ["Bhairahawa"], "culture": "nepali"}, "Pokhara": {"settlements": ["Muktinath", "Pokhara"], "culture": "nepali"}, "Mangyul": {"settlements": ["Dzongka", "Tingri", "Shelkar", "Gyirong"], "culture": "zhangzhung"}, "Janakpur": {"settlements": ["Birgunj", "Devghat", "Janakpur"], "culture": "nepali"}, "Kathmandu": {"settlements": ["Pashupatinath", "Kathmandu", "Bhaktapur"], "culture": "nepali"}, "Limbuwan": {"settlements": ["Taplejung", "Tambar"], "culture": "nepali"}, "Angouleme": {"settlements": ["Jarnac", "Fontdouce", "Richemont", "Angouleme", "Larochefoucauld", "Latranchade", "Cognac", "Bassac"], "culture": "occitan"}, "Sikkim": {"settlements": ["Gyalshing", "Mangan", "Gangdoz"], "culture": "nepali"}, "Paro": {"settlements": ["Kyichu", "Paro", "Hungrel"], "culture": "bodpa"}, "Bumthang": {"settlements": ["Bumthang", "Jambay", "Trongsa"], "culture": "bodpa"}, "Monyul": {"settlements": ["Itanagar", "Sepla", "Tawang"], "culture": "bodpa"}, "Lhoyu": {"settlements": ["Lhoyu", "Anini"], "culture": "bodpa"}, "Rutog": {"settlements": ["Rutog", "Rawang Rutog"], "culture": "zhangzhung"}, "Tsaparang": {"settlements": ["Tsaparang", "Tholing", "Tholinggompa"], "culture": "zhangzhung"}, "Gar": {"settlements": ["Gar", "Senggezangbo", "Kunsa"], "culture": "zhangzhung"}, "Pangong": {"settlements": ["Khumak", "Pangong"], "culture": "zhangzhung"}, "Kunlun": {"settlements": [], "culture": "zhangzhung"}, "Bordeaux": {"settlements": ["Blaye", "Lareole", "Bordeaux", "Bourg", "Libourne", "Lasauve", "Stemilion"], "culture": "basque"}, "Kyunglung": {"settlements": ["Monicer"], "culture": "zhangzhung"}, "Purang": {"settlements": ["Khorzhak", "Purang"], "culture": "zhangzhung"}, "Sakya": {"settlements": ["Pelsakya", "Sakya", "Geding"], "culture": "zhangzhung"}, "Coqen": {"settlements": [], "culture": "zhangzhung"}, "Gerze": {"settlements": [], "culture": "zhangzhung"}, "Samtho": {"settlements": [], "culture": "sumpa"}, "Taktse": {"settlements": ["Qonggyai", "Taktse"], "culture": "bodpa"}, "Gyantse": {"settlements": ["Bainang", "Palcho", "Gyantse"], "culture": "bodpa"}, "Lhasa": {"settlements": [], "culture": "sumpa"}, "Shigatse": {"settlements": ["Shalu", "Tashilhunpo", "Shigatse", "Samzhubze"], "culture": "sumpa"}, "Ormond": {"settlements": ["Cahir", "Cashel", "Clonmel", "Lismore", "Roscrea", "Fethard", "Waterford", "Nenagh"], "culture": "irish"}, "Albret": {"settlements": ["Gabarret", "Bazas", "Latestedebuch", "Roquefort", "Mimizan", "Tartas", "Labrit"], "culture": "basque"}, "Nyingchi": {"settlements": ["Drakchi", "Nyingchi", "Lamaling"], "culture": "tangut"}, "Nagormo": {"settlements": [], "culture": "tangut"}, "Fuqi": {"settlements": ["Shatuo", "Fuqi"], "culture": "tangut"}, "Nangqen": {"settlements": ["Tana", "Tana B"], "culture": "tangut"}, "Lingtsang": {"settlements": ["Serxu"], "culture": "tangut"}, "Markam": {"settlements": [], "culture": "tangut"}, "Dege": {"settlements": ["Dzongsar", "Palpung", "Dege"], "culture": "tangut"}, "Nyima": {"settlements": ["Nyima"], "culture": "zhangzhung"}, "Qamdo": {"settlements": ["Riwoche", "Qamdo", "Karub"], "culture": "tangut"}, "Labourd": {"settlements": ["Bayonne", "Sorde", "Dax", "Stsever", "Sauveterre", "Labastideclairence", "Aire"], "culture": "basque"}, "Pamir": {"settlements": ["Kala Panja", "Vanj", "Daroot Korgon", "Zamr I Atish Parast"], "culture": "sogdian"}, "Jiuquan": {"settlements": ["Kongtong", "Jiuquan", "Suzhou"], "culture": "han"}, "Ejin": {"settlements": [], "culture": "uyghur"}, "Yungguan": {"settlements": ["Yungguan", "Shouchang"], "culture": "han"}, "Barkul": {"settlements": [], "culture": "uyghur"}, "Dunkheger": {"settlements": ["Mori", "Dunkheger", "Gucheng", "Jiangjunmiao", "Hou Pulei", "Yulishi"], "culture": "uyghur"}, "Kumtag": {"settlements": ["Kumtag", "Chiting"], "culture": "tocharian"}, "Lopnor": {"settlements": ["Lopnor"], "culture": "tocharian"}, "Navarra": {"settlements": ["Olite", "Leyre", "Estella", "Tafalla", "Pamplona", "Carcastillo", "Sanguesa"], "culture": "basque"}, "Yuni": {"settlements": ["Ruoqiang", "Yuni"], "culture": "tocharian"}, "Mingoi": {"settlements": ["Shorshuq", "Mingoi", "Qigexing"], "culture": "tocharian"}, "Cadota": {"settlements": ["Niya"], "culture": "tocharian"}, "Keriya": {"settlements": ["Dandan Uilik", "Pimo", "Keriya"], "culture": "saka"}, "Karghalik": {"settlements": ["Karghalik"], "culture": "saka"}, "Yopurga": {"settlements": ["Jiashi", "Yopurga"], "culture": "saka"}, "Artux": {"settlements": ["Atush"], "culture": "saka"}, "Uchturpan": {"settlements": ["Uqturpan", "Yezheguan", "Wensu"], "culture": "tocharian"}, "Kubera": {"settlements": ["Subashi", "Kumtura", "Kizil", "Kubera"], "culture": "tocharian"}, "Viscaya": {"settlements": ["Bilbao", "Sansebastian", "Guernica", "Onate", "Vitoria", "Tolosa", "Irun", "Eibar"], "culture": "basque"}, "Dariya": {"settlements": ["Fayd", "An Nibaj", "Zubala", "Al Ajfur", "At Talabiya", "Al Qaryatan"], "culture": "levantine_arabic"}, "Uwal": {"settlements": ["Muharraq", "Umm As Sabaan", "Manama", "Sitra", "Aldur", "Umm Al Nasan", "Jidda", "Hamala"], "culture": "bedouin_arabic"}, "Zabid": {"settlements": ["Mukha", "Zabid", "Al Mahjam", "Hays", "Fasal", "Ghalafiqa", "Mawr"], "culture": "bedouin_arabic"}, "Najran": {"settlements": ["Najran", "Huth", "Sada"], "culture": "bedouin_arabic"}, "Al Ahqaf": {"settlements": ["Al Ahqaf", "Sabwa", "Al Abr"], "culture": "bedouin_arabic"}, "Tihama": {"settlements": ["Attar", "Abs", "Hali", "As Suqaiq", "Harad", "Hamr", "Bays"], "culture": "bedouin_arabic"}, "Khaybar": {"settlements": ["Haura", "Rabig", "Khaybar", "Algiar", "Soridan", "Badr", "Yanbu"], "culture": "bedouin_arabic"}, "Maragha": {"settlements": ["Kursara", "Maragheh", "Miyaneh"], "culture": "kurdish"}, "Badghis": {"settlements": ["Zurabad", "Kusuya", "Malin", "Kuhsim", "Buzgan", "Pushang", "Jabal Al Adda"], "culture": "persian"}, "Kanj Rustaq": {"settlements": ["Diza", "Kusak", "Baghsur"], "culture": "persian"}, "Asturias De Santillana": {"settlements": ["Santillanadelmar", "Santander", "Laredo", "Santona", "Suances", "Sanvicente", "Reinosa", "Camargo", "Castrourdiales"], "culture": "visigothic"}, "Guzgan": {"settlements": ["Naryan", "Faryab", "Andkhud", "Usbuman", "Jahudan", "Talaqan", "Qasrahnaf"], "culture": "persian"}, "Amol": {"settlements": ["Amol", "Akhsisak", "Zamm"], "culture": "persian"}, "Sarakhs": {"settlements": ["Mazduran", "Dandanqan", "Maihana", "Sarakhs"], "culture": "persian"}, "Vakhan": {"settlements": ["Sughnan", "Daritubat", "Vakhan", "Ishkashim"], "culture": "sogdian"}, "Chaghaniyan": {"settlements": ["Di-L-Kifl", "Sapoltepa", "Termez", "Shuman", "Di-L-Qarnain", "Chaghaniyan", "Kalif"], "culture": "sogdian"}, "Nakhshab": {"settlements": ["Paykand", "Nakhsab"], "culture": "sogdian"}, "Khojand": {"settlements": ["Tunket", "Khavakend", "Sokh", "Asht", "Kendibadam", "Khojand", "Ilaq"], "culture": "sogdian"}, "Badakhshan": {"settlements": ["Badakhshan", "Jerm", "Kerran", "Kamar", "Rustaq", "Jarf", "Panj"], "culture": "sogdian"}, "Khaylam": {"settlements": ["Wankath", "Ardalankath", "Najm", "Miyanrudhan", "Khaylam", "Kasan", "Akhsikath"], "culture": "sogdian"}, "Asturias De Oviedo": {"settlements": ["Cangasdelnarcea", "Villaviciosa", "Norena", "Gijon", "Tineo", "Luarca", "Oviedo", "Cangasdeonis"], "culture": "visigothic"}, "Lhatok": {"settlements": ["Gonjo"], "culture": "tangut"}, "Mustang": {"settlements": ["Tetang", "Lo", "Chhonhup"], "culture": "zhangzhung"}, "Lhunze": {"settlements": [], "culture": "bodpa"}, "Bome": {"settlements": ["Zhamo"], "culture": "tangut"}, "Banbar": {"settlements": [], "culture": "sumpa"}, "Medog": {"settlements": [], "culture": "bodpa"}, "Lhunzhub": {"settlements": ["Reting"], "culture": "sumpa"}, "Kunggar": {"settlements": ["Kunggar", "Drigung"], "culture": "sumpa"}, "Amdo": {"settlements": [], "culture": "sumpa"}, "Xainza": {"settlements": [], "culture": "sumpa"}, "Coruna": {"settlements": ["Triacastela", "Mondonedo", "Viveiro", "Lugo", "Corunna", "Ferrol", "Burela", "Villalba"], "culture": "suebi"}, "Ogliastra": {"settlements": ["Tortoli", "Ballao", "Jerzu", "Bari Sardo", "Urzulei", "Ogliastra", "Muravera"], "culture": "italian"}, "Lhatse": {"settlements": ["Lhatse", "Gyangbumoche"], "culture": "zhangzhung"}, "Zhongba": {"settlements": ["Labrang"], "culture": "zhangzhung"}, "Gegyai": {"settlements": ["Zhungpa", "Gegyai"], "culture": "zhangzhung"}, "Qangtang": {"settlements": [], "culture": "sumpa"}, "Tsakha": {"settlements": [], "culture": "zhangzhung"}, "Gyesar": {"settlements": [], "culture": "zhangzhung"}, "Mainling": {"settlements": [], "culture": "bodpa"}, "Yumen": {"settlements": ["Baoen", "Dongshuwo", "Yumen", "Xiaxihao"], "culture": "han"}, "Delingha": {"settlements": ["Delingha"], "culture": "tangut"}, "Santiago": {"settlements": ["Vilagarcia", "Verin", "Tuy", "Pontevedra", "Padron", "Vigo", "Ourense", "Santiago"], "culture": "suebi"}, "Qaidam": {"settlements": [], "culture": "tangut"}, "Lenghu": {"settlements": [], "culture": "tangut"}, "Arjin": {"settlements": [], "culture": "sumpa"}, "Tanggula": {"settlements": ["Tongtian"], "culture": "sumpa"}, "Gallura": {"settlements": ["Bicinara", "Posada", "Dorgali", "Galtelli", "Aggius", "Olbia", "Lungone", "Nuoro"], "culture": "italian"}, "Zadoi": {"settlements": ["Qapugtang"], "culture": "tangut"}, "Torres": {"settlements": ["Valledoria", "Portotorres", "Alghero", "Sassari", "Ottana", "Bosa", "Oschiri", "Ardara"], "culture": "italian"}, "Cinarca": {"settlements": ["Bonifacio", "Filitosa", "Ajaccio", "Portevecchio", "Cinarca", "Propriano", "Bastelicaccia", "Sartene"], "culture": "italian"}, "Dulan": {"settlements": ["Reshui", "Dulan"], "culture": "tangut"}, "Nedong": {"settlements": ["Phagmodru", "Nedong", "Zetang"], "culture": "bodpa"}, "Porto": {"settlements": ["Guimaraes", "Moncao", "Arcosdevaldevez", "Pontedelima", "Braga", "Porto", "Barcelos", "Vianadocastelo"], "culture": "suebi"}, "Coimbra": {"settlements": ["Montereal", "Pedondo", "Viseu", "Cantanhede", "Condeixa", "Coimbra", "Aveiro", "Penela"], "culture": "suebi"}, "Leinster": {"settlements": ["Wexford", "Naas", "Carlow", "Leighlin", "Enniscorthy", "Glendalough", "Ferns", "Arklow"], "culture": "irish"}, "Lisboa": {"settlements": ["Santarem", "Alenquer", "Atouguia", "Lisboa", "Alcobaca", "Batalha", "Setubal"], "culture": "visigothic"}, "Alcacer Do Sal": {"settlements": ["Santiagodocacem", "Alvito", "Alcacovas", "Espinheiro", "Alcacerdosal", "Sines", "Grandola", "Montemoronovo"], "culture": "visigothic"}, "Silves": {"settlements": ["Castroverde", "Silves", "Aljustrel", "Ourique", "Monchique", "Odemira", "Almodovar", "Lagos"], "culture": "visigothic"}, "Faro": {"settlements": ["Saobrasdealportel", "Alcoutim", "Loule", "Faro", "Castromarim", "Aljezur", "Olhao", "Tavira"], "culture": "visigothic"}, "Niebla": {"settlements": ["Huelva", "Niebla", "Lepe", "Nerva", "Aljaraque", "Moguer", "Almonte", "Gibraleon"], "culture": "visigothic"}, "Cadiz": {"settlements": ["Jerez", "Arcos", "Alcaladelosgazules", "Cadiz", "Sanfernando", "Medinasidonia", "Sanlucadebarrameda", "Sanjosedelvalle"], "culture": "visigothic"}, "Algeciras": {"settlements": ["Estepona", "Casares", "Tarifa", "Sanroque", "Gibraltar", "Jimenadelafrontera", "Algericas", "Ronda"], "culture": "visigothic"}, "Malaga": {"settlements": ["Malaga", "Tamisa", "Antequera", "Coin", "Benalmadena", "Cartajima", "Velezmalaga", "Suel"], "culture": "visigothic"}, "Almeria": {"settlements": ["Baza", "Motril", "Almeria", "Vera", "Purchena", "Albox", "Pechina", "Berja"], "culture": "visigothic"}, "Murcia": {"settlements": ["Alcantarilla", "Cartagena", "Medinasiyasa", "Molinalaseca", "Lorca", "Murcia", "Nogalte", "Yecla"], "culture": "visigothic"}, "Hereford": {"settlements": ["Ewyas Harold", "Hereford", "Leominster", "Clifford", "Archenfield", "Brobury", "Ledbury", "St Ethelberts"], "culture": "welsh"}, "Denia": {"settlements": ["Benissa", "Denia", "Alicante", "Elche", "Orihuela", "Villena", "Castalla", "Albatera"], "culture": "visigothic"}, "Valencia": {"settlements": ["Chiva", "Gandia", "Cuartdepoblet", "Torrent", "Valencia", "Jativa", "Alberique", "Alacuas"], "culture": "visigothic"}, "Castellon": {"settlements": ["Nules", "Castellon", "Alpuente", "Morella", "Vilarreal", "Alcalaten", "Vinaros", "Burriana"], "culture": "visigothic"}, "Tarragona": {"settlements": ["Cambrils", "Amposta", "Tarragona", "Vendrell", "Spantortosa", "Reus", "Montblanc", "Sancugat"], "culture": "visigothic"}, "Albarracin": {"settlements": ["Montalban", "Hijar", "Alcaniz", "Calanda", "Calamocha", "Teruel", "Utrillas", "Albarracin"], "culture": "visigothic"}, "Calatayud": {"settlements": ["Cimballa", "Munebrega", "Calmarza", "Alhamadearagon", "Nuevalos", "Calatayud", "Piedra", "Daroca"], "culture": "visigothic"}, "Molina": {"settlements": ["Elpedregal", "Hinojosa", "Cabanillasdelcampo", "Elcasar", "Olmeda", "Maranchon", "Pinilla", "Molina"], "culture": "visigothic"}, "Cuenca": {"settlements": ["Siguenza", "Ucles", "Laspedroneras", "Guadalajara", "Tarancon", "Villanuevadelajara", "Motadelcuervo", "Cuenca"], "culture": "visigothic"}, "La Mancha": {"settlements": ["Quintanardelrey", "Lagineta", "Alarcon", "Laroda", "Barrax", "Munera", "Jorquera", "Tarazona"], "culture": "visigothic"}, "Almansa": {"settlements": ["Hellin", "Almansa", "Villarrobledo", "Alcaladeljucar", "Tobarra", "Caudete", "Pozocanada", "Albacete"], "culture": "visigothic"}, "Dyfed": {"settlements": ["Llandeilo", "Narberth", "Kidwelly", "St Davids", "Carmarthen", "Haverford", "Pembroke", "Dinefwr"], "culture": "welsh"}, "Granada": {"settlements": ["Granada", "Elvira", "Huelma", "Moclin", "Guadix", "Iznajar", "Jaen", "Baeza"], "culture": "visigothic"}, "Cordoba": {"settlements": ["Canetedelastorres", "Cabra", "Cordoba", "Belalcazar", "Andujar", "Alcolea", "Martos", "Lucena"], "culture": "visigothic"}, "Sevilla": {"settlements": ["Sevilla", "Carmona", "Ecija", "Sevimoron", "Doshermanas", "Laalgaba", "Utrera"], "culture": "visigothic"}, "Aracena": {"settlements": ["Aracena", "Facanias", "Cortegana", "Alajar", "Calanas", "Galaroza", "Italica", "Almonasterlareal"], "culture": "visigothic"}, "Badajoz": {"settlements": ["Merida", "Villalbadelosbarros", "Guarena", "Fuentedelmaestre", "Badajoz", "Jerezdeloscaballeros", "Almendralejo", "Zafra"], "culture": "visigothic"}, "Mertola": {"settlements": ["Portel", "Serpa", "Moura", "Mertola", "Noudal", "Mourao", "Monsaraz", "Beja"], "culture": "visigothic"}, "Evora": {"settlements": ["Marvao", "Evora", "Crato", "Portalegre", "Castelodevide", "Monforte", "Avis", "Ouguela"], "culture": "visigothic"}, "Castelo Branco": {"settlements": ["Sabugal", "Castelobranco", "Trancoso", "Acores", "Covilha", "Guarda", "Almeida", "Pinhel"], "culture": "suebi"}, "Braganza": {"settlements": ["Castelomelhor", "Azinhoso", "Chaves", "Vilareal", "Mogadouro", "Castelorodrigo", "Braganza", "Torredemoncorvo"], "culture": "suebi"}, "Astorga": {"settlements": ["Toreno", "Bembibre", "Camponaraya", "Astorga", "Cacabelos", "Ponferrada", "Fabero", "Ribadelago"], "culture": "suebi"}, "Glamorgan": {"settlements": ["Loughor", "Llandaff", "Caerphilly", "Ogmore", "Cardiff", "Neath", "Margam", "Swansea"], "culture": "welsh"}, "Leon": {"settlements": ["Cistierna", "Villablino", "Larobla", "Sanpedrodeperix", "Saldana", "Leon", "Sahagun", "Valenciadecampos"], "culture": "visigothic"}, "Zamora": {"settlements": ["Benavente", "Fermoselle", "Corrales", "Fuentesauco", "Sanabria", "Toro", "Zamora", "Polvorosa"], "culture": "visigothic"}, "Salamanca": {"settlements": ["Albadetormes", "Ciudadrodrigo", "Salbejar", "Carbajosadelasagrada", "Lumbrales", "Salamanca", "Bracamonte", "Terradillos"], "culture": "visigothic"}, "Alcantara": {"settlements": ["Alcantara", "Lasnavasdelmadrono", "Ceclavin", "Moraleja", "Lamata", "Racharachel", "Coria", "Brozas"], "culture": "visigothic"}, "Plasencia": {"settlements": ["Ventadelmoral", "Montehermoso", "Jarandilla", "Hervas", "Plasencia", "Talayuela", "Jaraiz", "Lazarza"], "culture": "visigothic"}, "Caceres": {"settlements": ["Alia", "Logrosan", "Alburquerque", "Arroyodelalluz", "Alcuescar", "Guadalupe", "Caceres", "Trujillo"], "culture": "visigothic"}, "Calatrava": {"settlements": ["Calatrava", "Alcazardesanjuan", "Villareal", "Alarcos", "Medellin", "Caracuel", "Almadeo", "Almodovardelcampo"], "culture": "visigothic"}, "Toledo": {"settlements": ["Fuensalida", "Madrid", "Orgaz", "Talavera", "Consuegra", "Tolemora", "Illescas", "Toledo"], "culture": "visigothic"}, "Valladolid": {"settlements": ["Medinadelcampo", "Tordesillas", "Penafiel", "Iscar", "Simancas", "Segovia", "Valladolid", "Avila"], "culture": "visigothic"}, "Burgos": {"settlements": ["Palencia", "Burgos", "Aguilardecampo", "Mirandadeebro", "Castrobarte", "Carrion", "Silos", "Arandadeduero"], "culture": "visigothic"}, "Austisland": {"settlements": ["Akureyri", "Glaumbaer", "Valpjotstadur", "Kirkjubaer", "Husavik", "Goddalir", "Holar", "Hrisey"], "culture": "norse"}, "Gwent": {"settlements": ["Tintern", "Caerleon", "Monmouth", "Brecon", "Chepstow", "Abergavenny", "Caerwent", "Newport"], "culture": "welsh"}, "Soria": {"settlements": ["Soria", "Osma", "Almazan", "Sanleonardodeyague", "Gormaz", "Covaleda", "Castromoro", "Medinacelli"], "culture": "visigothic"}, "Najera": {"settlements": ["Arnedo", "Logrone", "Haro", "Alfara", "Santodomingodelacalzada", "Zizurmayor", "Calahorra", "Najera"], "culture": "basque"}, "Zaragoza": {"settlements": ["Alagon", "Zaragoza", "Veruela", "Borja", "Epila", "Medianadearagon", "Caspe", "Ejea"], "culture": "visigothic"}, "Lleida": {"settlements": ["Balaguer", "Agramunt", "Cervera", "Lleida", "Solsona", "Borgesblanques", "Verdu", "Tarrega"], "culture": "visigothic"}, "Barcelona": {"settlements": ["Barcelona", "Vic", "Igualada", "Osona", "Berga", "Provencana", "Manresa", "Vallparadis"], "culture": "visigothic"}, "Empuries": {"settlements": ["Banyoles", "Cerdana", "Castelldaro", "Girona", "Figueras", "Labisbaldemporda", "Empuries", "Besalu"], "culture": "visigothic"}, "Urgell": {"settlements": ["Valledebohi", "Viella", "Pallars", "Elpuidesegur", "Urgell", "Puigcerda", "Tremp", "Suert"], "culture": "visigothic"}, "Alto Aragon": {"settlements": ["Almudevar", "Huesca", "Loarre", "Alquezar", "Ayerbe", "Jaca", "Barbastro", "Uncastillo"], "culture": "basque"}, "Bearn": {"settlements": ["Lescar", "Pau", "Montaner", "Mauleonlicharre", "Oloron", "Orthez", "Tarbes", "Morlaas"], "culture": "basque"}, "Armagnac": {"settlements": ["Lectoure", "Laplume", "Auch", "Eauze", "Castelnau", "Lisle", "Mirande"], "culture": "occitan"}, "Gloucester": {"settlements": ["Cirencester", "Winchcombe", "Tewkesbury", "Hailes", "Gloucester", "Sudeley", "Cheltenham", "Bristol"], "culture": "saxon"}, "Foix": {"settlements": ["Usson", "Foix", "Mirepoix", "Stgaudens", "Roquefeuil", "Stbertrand", "Montsegur"], "culture": "visigothic"}, "Rosello": {"settlements": ["Elna", "Oltrera", "Perpinya", "Prada", "Cuixa", "Canigo", "Cotlliure", "Ceret"], "culture": "visigothic"}, "Narbonne": {"settlements": ["Puisserguier", "Queribus", "Stponsdethomieres", "Narbonne", "Beziers", "Agde", "Castres", "Albi"], "culture": "visigothic"}, "Carcassonne": {"settlements": ["Minerve", "Carcassonne", "Saissac", "Alet", "Lastours", "Termes", "Lagrasse", "Cabaret"], "culture": "visigothic"}, "Toulouse": {"settlements": ["Montauban", "Muret", "Castelnaudary", "Montgiscard", "Lombez", "Lavaur", "Toulouse", "Hautpoul"], "culture": "occitan"}, "Agen": {"settlements": ["Cahors", "Rocamadour", "Figeac", "Moissac", "Penne", "Agen", "Luzech", "Blanquefort"], "culture": "occitan"}, "Perigord": {"settlements": ["Chancelade", "Sarlat", "Bergerac", "Perigueux", "Baneuil", "Biron", "Bonaguil", "Auberoche"], "culture": "occitan"}, "Auvergne": {"settlements": ["Domeyrat", "Brioude", "Carlat", "Aurillac", "Murol", "Tournoel", "Mozac", "Clermont"], "culture": "occitan"}, "Rouergue": {"settlements": ["Villefranche", "Estaing", "Rodez", "Millau", "Najac", "Vabres", "Staffrique", "Caylus"], "culture": "occitan"}, "Gevaudan": {"settlements": ["Mende", "Tournel", "Stsauveur", "Florac", "Marvejols", "Lepuy", "Grezes", "Apchier"], "culture": "visigothic"}, "Oxford": {"settlements": ["Oxford", "Abingdon", "Banbury", "Wallingford", "Aylesbury", "Buckingham", "Eynsham", "Reading"], "culture": "saxon"}, "Montpellier": {"settlements": ["Beaucaire", "Maguelone", "Montpellier", "Aiguesmortes", "Saintguilhemledesert", "Bagnolssurceze", "Nimes", "Melgueil"], "culture": "visigothic"}, "Provence": {"settlements": ["Aix", "Castellane", "Frejus", "Tarascon", "Marseille", "Grimaud", "Arles", "Grasse"], "culture": "visigothic"}, "Venaissin": {"settlements": ["Carpentras", "Orange", "Chateauneufdupape", "Mondragon", "Avignon", "Stpaul", "Venasque", "Cavaillon"], "culture": "visigothic"}, "Viviers": {"settlements": ["Largentiere", "Joyeuse", "Aubenas", "Viviers", "Privas", "Albalaromaine", "Tournon", "Lecheylard"], "culture": "visigothic"}, "Forez": {"settlements": ["Chalmazel", "Montbrison", "Couzan", "Charlieu", "Feurs", "Stetienne", "Thiers", "Roanne"], "culture": "occitan"}, "Macon": {"settlements": ["Davaye", "Beaujeu", "Fuisse", "Cluny", "Berze", "Macon", "Villefranchesursaone", "Lugny"], "culture": "old_frankish"}, "Charolais": {"settlements": ["Montstvincent", "Paray", "Perrecy", "Digoine", "Joncy", "Charolles", "Toulonsurarroux", "Semurenbrionnais"], "culture": "old_frankish"}, "Lyon": {"settlements": ["Stjeanbaptiste", "Irigny", "Chessy", "Lyon", "Lacenas", "Brindas", "Pusignan", "Anse"], "culture": "old_frankish"}, "Dauphine Viennois": {"settlements": ["Montelimar", "Valence", "Chartreuse", "Albon", "Valreas", "Grenoble", "Vienne", "Stantoine"], "culture": "occitan"}, "Forcalquier": {"settlements": ["Vaison", "Gap", "Briancon", "Nyons", "Sisteron", "Forcalquier", "Embrun", "Apt"], "culture": "visigothic"}, "Wiltshire": {"settlements": ["Wilton", "Sarum", "Ramsbury", "Malmesbury", "Clarendon", "Salisbury", "Marlborough", "Devizes"], "culture": "saxon"}, "Nice": {"settlements": ["Mentone", "Campogrosso", "Nizza", "Lantosque", "Sanremo", "Contes", "Antibes", "Monaco"], "culture": "lombard"}, "Saluzzo": {"settlements": ["Cuneo", "Verzuolo", "Paesana", "Savigliano", "Caraglio", "Busca", "Saluzzo"], "culture": "lombard"}, "Monferrato": {"settlements": ["Asti", "Casale", "Monferrato", "Acqui", "Tortona", "Alba", "Canelli", "Biella"], "culture": "lombard"}, "Genoa": {"settlements": ["Ventimiglia", "Luna", "Albenga", "Genoa", "Savona", "Chiavari", "Rapallo", "Fosdinovo"], "culture": "lombard"}, "Pavia": {"settlements": ["Bobbio", "Alessandria", "Pavia", "Voghera", "Colorno", "Montebello", "Piacenza", "Casteggio"], "culture": "lombard"}, "Lombardia": {"settlements": ["Milano", "Vigevano", "Legnano", "Lodi", "Chiavenna", "Como", "Monza", "Maggiore"], "culture": "lombard"}, "Piemonte": {"settlements": ["Auriate", "Torino", "Settimo", "Ferrero", "Crevacuore", "Messarano", "Novara", "Ivrea"], "culture": "lombard"}, "Savoie": {"settlements": ["Bussoleno", "Montjovet", "Aosta", "Pombia", "Vercelli", "Ciamberi", "Savosusa", "Tarentaise"], "culture": "old_frankish"}, "Valais": {"settlements": ["Aigle", "Monthey", "Siders", "Brig", "Greyerz", "Chateaudoex", "Sitten", "Martigny"], "culture": "german"}, "Geneve": {"settlements": ["Thonon", "Romainmotier", "Lausanne", "Echallens", "Orbe", "Nyon", "Geneve", "Aubonne"], "culture": "old_frankish"}, "Surrey": {"settlements": ["Woking", "Southwark", "Chertsey", "Farnham", "Croydon", "Lambeth", "Guildford", "Waverley"], "culture": "saxon"}, "Chalons": {"settlements": ["Tournus", "Chamilly", "Brancion", "Stjeandelosne", "Chalon", "Seurre", "Cuisery", "Louhans"], "culture": "old_frankish"}, "Neuchatel": {"settlements": ["Fribourg", "Neuchatel", "Stimier", "Grandson", "Murten", "Avences", "Yverdon", "Estavayer"], "culture": "german"}, "Aargau": {"settlements": ["Basel", "Solothurn", "Schaffhausen", "Lenzburg", "Laufenburg", "Aargau", "Habsburg"], "culture": "german"}, "Orvieto": {"settlements": ["Orvieto", "Otricoli", "Ciconia", "Alviano", "Montecastrilli", "Amelia", "Narni", "Baschi"], "culture": "italian"}, "Bern": {"settlements": ["Kyburg", "Bern", "Interlaken", "Sursee", "Langenthal", "Luzern", "Sempach", "Biel"], "culture": "german"}, "Schwyz": {"settlements": ["Zug", "Zurich", "Stans", "Schwyz", "Winterthur", "Glarus", "Engelberg", "Altdorf"], "culture": "german"}, "Grisons": {"settlements": ["Bellinzona", "Domo", "Musso", "Mendrisio", "Disentis", "Lugano", "Locarno", "Biasca"], "culture": "german"}, "Chur": {"settlements": ["Davos", "Maienfeld", "Illanz", "Glurns", "Churwalden", "Chur", "Thusis", "Zuoz"], "culture": "german"}, "St Gallen": {"settlements": ["Vaduz", "Altstatten", "Herisau", "Frauenfeld", "Appenzell", "Lichtensteig", "Stgallen", "Rheineck"], "culture": "german"}, "Schwaben": {"settlements": ["Lindau", "Heiligenberg", "Hohenberg", "Wangen", "Konstanz", "Uberlingen", "Friedrichshafen", "Tubingen"], "culture": "german"}, "Sussex": {"settlements": ["Chichester", "Lewes", "Pevensey", "Arundel", "Bramber", "Hastings", "Bodiam", "Rye"], "culture": "saxon"}, "Breisgau": {"settlements": ["Offenburg", "Zahringen", "Rottweil", "Lohrrach", "Freiburg", "Breisach", "Stblasien", "Lahr"], "culture": "german"}, "Furstenberg": {"settlements": ["Zollern", "Baar", "Donaueschingen", "Haslach", "Furstenberg", "Wolfach", "Hirsau", "Villingen"], "culture": "german"}, "Ulm": {"settlements": ["Ulm", "Zwiefalten", "Biberach", "Goppingen", "Isny", "Memmingen", "Erbach", "Teck"], "culture": "german"}, "Wurttemberg": {"settlements": ["Asperg", "Esslingen", "Waiblingen", "Stuttgart", "Gmund", "Staufen", "Reutlingen", "Heilbronn"], "culture": "german"}, "Wurzburg": {"settlements": ["Aschaffenburg", "Wurzburg", "Schwarzenberg", "Theiheim", "Mainderheim", "Marienberg", "Schweinfurt", "Hammelburg"], "culture": "german"}, "Thuringen": {"settlements": ["Schmalkalden", "Salzungen", "Eichsfeld", "Muhlhausen", "Arnstadt", "Reuss", "Henneberg", "Erfurt"], "culture": "german"}, "Weimar": {"settlements": ["Weimar", "Nordhausen", "Memelsen", "Gotha", "Apoldoa", "Walkenried", "Gera", "Jena"], "culture": "old_saxon"}, "Braunschweig": {"settlements": ["Braunschweig", "Waldeck", "Gandersheim", "Bielefeld", "Helmstedt", "Hildesheim", "Wolfenbuttel"], "culture": "old_saxon"}, "Luneburg": {"settlements": ["Bardowick", "Reppenstedt", "Evern", "Uelzen", "Luneburg", "Gifhorn", "Ludersburg", "Thomasburg"], "culture": "old_saxon"}, "Celle": {"settlements": ["Celle", "Hannover", "Wittingen", "Hermannsburg", "Nienburg", "Wedemark", "Ravensberg", "Herford"], "culture": "old_saxon"}, "Winchester": {"settlements": ["Southampton", "Portchester", "Carisbrooke", "Winchester", "St Swithun", "Wherwell", "Romsey", "Andover"], "culture": "saxon"}, "Mecklemburg": {"settlements": ["Mecklemburg", "Parchim", "Lutzow", "Grevesmuhlen", "Gevezin", "Wismar", "Hagenow"], "culture": "pommeranian"}, "Hamburg": {"settlements": ["Hamburg", "Altona", "Buxtehude", "Brunsbuttel", "Niendorf", "Lokstedt", "Dithmarschen"], "culture": "old_saxon"}, "Lubeck": {"settlements": ["Ratzeburg", "Wulfsdorf", "Travemunde", "Starigard", "Schlutup", "Bucu", "Weslo", "Lubeck"], "culture": "pommeranian"}, "Holstein": {"settlements": ["Itzehoe", "Reinholdsburg", "Lauenburg", "Kiel", "Elmshorn", "Segeberg"], "culture": "old_saxon"}, "Slesvig": {"settlements": ["Aabenraa", "Haderslev", "Slesvig", "Ribe", "Flensborg", "Tonder", "Kolding", "Sonderborg", "Hedeby"], "culture": "norse"}, "Fyn": {"settlements": ["Svendborg", "Kerteminde", "Odense", "Bogense", "Faaborg", "Middelfart", "Nyborg", "Assens"], "culture": "norse"}, "Sjaelland": {"settlements": ["Kobenhavn", "Ringsted", "Kalundborg", "Naestved", "Vordingborg", "Slagelse", "Helsingor", "Roskilde"], "culture": "norse"}, "Jylland": {"settlements": ["Aarhus", "Skive", "Ringkobing", "Jelling", "Randers", "Viborg", "Skagen", "Horsens", "Aalborg"], "culture": "norse"}, "Agder": {"settlements": ["Holt", "Grimstad", "Flekkefjord", "Hylestad", "Sirdal", "Horga", "Visedal"], "culture": "norse"}, "Rogaland": {"settlements": ["Hesby", "Stavanger", "Bygdeborg", "Jonegarden", "Naerbo", "Klepp", "Eikundarsund"], "culture": "norse"}, "Dorset": {"settlements": ["Weymouth", "Wimborne", "Lyme", "Shaftesbury", "Dorchester", "Wareham", "Corfe", "Sherborne"], "culture": "saxon"}, "Telemark": {"settlements": ["Fyresdal", "Eidsborg", "Hitterdals", "Gimsoy", "Fredriksten", "Skien", "Seljord", "Grenland"], "culture": "norse"}, "Vestfold": {"settlements": ["Horten", "Nore", "Uvdal", "Re", "Tonsberg", "Skiringssal", "Arendall", "Kaupang"], "culture": "norse"}, "Akershus": {"settlements": ["Bergheim", "Eidsvoll", "Baerum", "Jessheim", "Nes", "Akershus", "Isegran", "Oslo"], "culture": "norse"}, "Oppland": {"settlements": ["Flesberg", "Lillehammer", "Dovre", "Slidre", "Garmo", "Favang", "Lom", "Oyer"], "culture": "norse"}, "Bergenshus": {"settlements": ["Aurland", "Vik", "Bergen", "Hove", "Bergenhus", "Ask", "Fedje", "Kinsarvik"], "culture": "norse"}, "Trondelag": {"settlements": ["Audunborg", "Austratt", "Sverresborg", "Trondheim", "Steinvikholm", "Borgund", "Nidaros"], "culture": "norse"}, "Hedmark": {"settlements": ["Eidskog", "Kongsvinger", "Hamarhus", "Loten", "Hamar", "Vang", "Stange", "Elverum"], "culture": "norse"}, "Naumadal": {"settlements": ["Hegra", "Logtun", "Halsstein", "Lade", "Levanger", "Tinghaugen", "Leksvik"], "culture": "norse"}, "Halogaland": {"settlements": ["Hattfjelldalen", "Veiga", "Somna", "Bindal", "Lein", "Brunnoy", "Mosjoen", "Alstahaug"], "culture": "norse"}, "Lappland": {"settlements": ["Kiruna"], "culture": "lappish"}, "Somerset": {"settlements": ["Muchelney", "Wells", "Ilchester", "Taunton", "Castle Cary", "Bath", "Cleeve", "Glastonbury"], "culture": "saxon"}, "Vasterbotten": {"settlements": ["Skelleftea"], "culture": "lappish"}, "Angermanland": {"settlements": ["Ulvo", "Natra"], "culture": "norse"}, "Jamtland": {"settlements": ["Husan", "Mjalleborgen", "Vasterhus"], "culture": "norse"}, "Medelpad": {"settlements": ["Selanger", "Alno", "Skon"], "culture": "norse"}, "Herjedalen": {"settlements": ["Tannas", "Hogvalen", "Sveg"], "culture": "norse"}, "Halsingland": {"settlements": ["Norrala", "Hog", "Jattendal"], "culture": "norse"}, "Gastrikland": {"settlements": ["Valbo", "Hamrange", "Hedesunda", "Hille", "Farnebo"], "culture": "norse"}, "Dalarna": {"settlements": ["Hedemora", "Borganas", "Kopparberg"], "culture": "norse"}, "Varmland": {"settlements": ["Nordmark", "Josse", "Kil", "Arvika", "Gillberg", "Fryksdal", "Saxholm", "Vase"], "culture": "norse"}, "Vastmanland": {"settlements": ["Koping", "Vasteras", "Kopingshus", "Arboga"], "culture": "norse"}, "Devon": {"settlements": ["Axminster", "Tavistock", "Totnes", "Buckfast", "Exeter", "Lydford", "Crediton", "Dartmouth"], "culture": "breton"}, "Uppland": {"settlements": ["Sigtuna", "Stockholm", "Alsno", "Enkoping", "Birka", "Hatuna", "Osteras", "Uppsala"], "culture": "norse"}, "Aland": {"settlements": ["Sund", "Geta", "Kastelholm"], "culture": "norse"}, "Sodermanland": {"settlements": ["Nykoping", "Vaderbrunn", "Hundhamra", "Eskilstuna", "Telge", "Torshalla", "Strangnas", "Gripsholm"], "culture": "norse"}, "Ostergotland": {"settlements": ["Nasborg", "Stegeborg", "Jonkoping"], "culture": "norse"}, "Narke": {"settlements": ["Hallsberg", "Kumla", "Orebro", "Mosas", "Goksholm"], "culture": "norse"}, "Dal": {"settlements": ["Dalaborg"], "culture": "norse"}, "Viken": {"settlements": ["Svenneby", "Kungahalla", "Svarteborg", "Bagahus"], "culture": "norse"}, "Vastergotland": {"settlements": ["Husaby", "Galakvist", "Ymseborg", "Varnhem", "Lacko"], "culture": "norse"}, "Smaland": {"settlements": ["Piksborg", "Vaxjo"], "culture": "norse"}, "Farrah": {"settlements": ["Khakisafed", "Qalaikah", "Baladuluk", "Anardara", "Farrah", "Juwayn", "Shibkoh", "Bakwa"], "culture": "afghan"}, "Tyrconnell": {"settlements": ["Gartan", "Ballyshannon", "Moville", "Fahan", "Kilmacrenan", "Raphoe", "Donegal", "Ballymacswiney"], "culture": "irish"}, "Worcester": {"settlements": ["Worcester", "Pershore", "Kidderminster", "Laughern", "Malvern", "Evesham", "Droitwich", "Bromsgrove"], "culture": "saxon"}, "Oland": {"settlements": ["Kopingsvik", "Ottenby", "Algutsrum", "Borgholm"], "culture": "norse"}, "Gotland": {"settlements": ["Visborg", "Visby", "Slite", "Geatish Roma", "Othem"], "culture": "norse"}, "Halland": {"settlements": ["Baastad", "Falkenberg", "Laholm", "Varberg", "Getinge", "Halmstad", "Aranaes", "Kungsbacka"], "culture": "norse"}, "Skane": {"settlements": ["Uppakra", "Trelleborg", "Helsingborg", "Malmo", "Herrevad", "Lund", "Lillohus", "Ystad", "Dalby"], "culture": "norse"}, "Rugen": {"settlements": ["Tribuzin", "Ralswiek", "Charenza", "Barth", "Rugard", "Hiddensee", "Putbus", "Arkona"], "culture": "pommeranian"}, "Bornholm": {"settlements": ["Hammershus", "Ronne", "Aakirkeby", "Nexo", "Hasle", "Svaneke", "Knudsker", "Gudhjem"], "culture": "norse"}, "Rostock": {"settlements": ["Ahrensberg", "Stargard", "Damgarten", "Malchin", "Gustrow", "Strelitz", "Penzlin", "Rostock"], "culture": "pommeranian"}, "Werle": {"settlements": ["Demmin", "Greifswald", "Templin", "Stralsund", "Tribsees", "Treptow", "Waren", "Friedland"], "culture": "pommeranian"}, "Wolgast": {"settlements": ["Ueckermunde", "Usedom", "Zinnowitz", "Kemnitz", "Zussow", "Wolgast", "Eggesin", "Anklam"], "culture": "pommeranian"}, "Altmark": {"settlements": ["Walbeck", "Halberstedt", "Salzwedel", "Luchow", "Stendal", "Tangermunde", "Werben", "Osterburg"], "culture": "old_saxon"}, "Cornwall": {"settlements": ["St Michael", "Liskeard", "Bodmin", "St Germans", "Truro", "Restormel", "Tintagel", "Launceston"], "culture": "breton"}, "Anhalt": {"settlements": ["Magdeburg", "Arnstein", "Mansfeld", "Dessau", "Bernburg", "Zerbst", "Querfurt", "Haldensleben"], "culture": "old_saxon"}, "Plauen": {"settlements": ["Halle", "Naumburg", "Zeitz", "Merseburg", "Leipzig", "Zwickau", "Knobelsdorf", "Plauen"], "culture": "pommeranian"}, "Meissen": {"settlements": ["Wettin", "Dresden", "Strehla", "Meissen", "Belgern", "Dohna", "Radeburg", "Rabenau"], "culture": "pommeranian"}, "Bamberg": {"settlements": ["Ansbach", "Babenberg", "Cadolzburg", "Crailsheim", "Colmberg", "Bamberg", "Roth", "Uffenheim"], "culture": "german"}, "Nurnberg": {"settlements": ["Kulmbach", "Ellwangen", "Nordlingen", "Eichstatt", "Erlangen", "Furth", "Hohenburg", "Nurnberg"], "culture": "german"}, "Kempten": {"settlements": ["Augsburg", "Hochstadt", "Rain", "Kaufbeuren", "Friedberg", "Zumarshausen", "Kempten", "Donauworth"], "culture": "german"}, "Tirol": {"settlements": ["Ried", "Nenzing", "Sterzing", "Stanton", "Dornbirn", "Imst", "Bregenz", "Landeck"], "culture": "german"}, "Trent": {"settlements": ["Bozen", "Meran", "Riva", "Brixen", "Rovereto", "Trento", "Schlanders"], "culture": "lombard"}, "Brescia": {"settlements": ["Salo", "Lumezzane", "Montichiari", "Bergamo", "Brescia", "Castiglione", "Peschiera", "Treviglio"], "culture": "lombard"}, "Verona": {"settlements": ["Barbarano", "Sanmartino", "Verona", "Montecchio", "Vicenza", "Schio", "Lonigo", "Arzignano"], "culture": "lombard"}, "Middlesex": {"settlements": ["Staines", "Westminster", "Fulham", "Harrow", "Chelsea", "St Pauls", "London", "Tottenham"], "culture": "saxon"}, "Cremona": {"settlements": ["Cremona", "Sospiro", "Casalmaggiore", "Castelgoffredo", "Manerbio", "Vescovato", "Crema", "Viadana"], "culture": "lombard"}, "Parma": {"settlements": ["Noceto", "Massa", "Fontanellato", "Guastalla", "Laspezia", "Parma", "Fidenza", "Fornovo"], "culture": "lombard"}, "Modena": {"settlements": ["Modena", "Sabbioneta", "Mirandola", "Novellara", "Carpi", "Sassuolo", "Reggionellemila", "Bomporto"], "culture": "lombard"}, "Lucca": {"settlements": ["Viareggio", "Pistoia", "Seravezza", "Calcinaia", "Altopascio", "Capannori", "Cascina", "Lucca"], "culture": "lombard"}, "Corsica": {"settlements": ["Alando", "Calvi", "Aleria", "Bastia", "Corte", "Morosaglia", "Luri", "Algajola"], "culture": "italian"}, "Arborea": {"settlements": ["Sanluri", "Sorgono", "Tharros", "Oristano", "Cabras", "Santa Giusta", "Pabillonis", "Fordongianus"], "culture": "italian"}, "Cagliari": {"settlements": ["Dolianova", "Capoterra", "Iglesias", "Assemini", "Carbonia", "Cagliari", "Santaigia"], "culture": "italian"}, "Pisa": {"settlements": ["Canefro", "Livorno", "Pisa", "Volterra", "Vicopisano", "Portoferraio", "Sanminiato", "Giglio"], "culture": "italian"}, "Firenze": {"settlements": ["Montevarchi", "Lucignano", "Sansepolcro", "Firenze", "Fiesole", "Prato", "Arezzo", "Certaldo"], "culture": "italian"}, "Urbino": {"settlements": ["Gubbio", "Sanmarino", "Fano", "Cittadicastello", "Fossombrone", "Urbino", "Sanseverino", "Montefeltro"], "culture": "italian"}, "Faereyar": {"settlements": ["Kvivik", "Funningur", "Skansin", "Kirkjubour", "Hov", "Klaksvik", "Torshavn", "Sandur"], "culture": "pictish"}, "Siena": {"settlements": ["Siena", "Cortona", "Montalcino", "Montepulciano", "Monteriggioni", "Sangimignano", "Pienza"], "culture": "italian"}, "Piombino": {"settlements": ["Piombino", "Radicofani", "Follonica", "Sanvincenzo", "Campiglia", "Barrati", "Populonia", "Suvereto"], "culture": "italian"}, "Orbetello": {"settlements": ["Roselle", "Sorano", "Vetulonia", "Orbetello", "Sovana", "Rusellae", "Pitigliano", "Grosseto"], "culture": "italian"}, "Roma": {"settlements": ["Tivoli", "Viterbo", "Tusculum", "Terracina", "Sutri", "Aragni", "Roma", "Ostia"], "culture": "italian"}, "Napoli": {"settlements": ["Turris Octava", "Afragola", "Ischia", "Portici", "Cumae", "Aversa", "Napoli", "Pozzuoli"], "culture": "greek"}, "Benevento": {"settlements": ["Avellino", "Conza", "Frigento", "Sanangelo", "Benevento", "Trevico", "Montemarono", "Ascoli"], "culture": "lombard"}, "Salerno": {"settlements": ["Lucania", "Acerno", "Eboli", "Nocera", "Sarno", "Acenzera", "Salerno", "Agropoli"], "culture": "lombard"}, "Consenza": {"settlements": ["Scalea", "Cerenzia", "Rossano", "Cosenza", "Argentano", "Strongoli", "Crotone"], "culture": "greek"}, "Reggio": {"settlements": ["Gerace", "Bova", "Belcastro", "Nicotera", "Squillace", "Reggio", "Mileto", "Tropea"], "culture": "greek"}, "Messina": {"settlements": ["Taormina", "Furnari", "Lipari", "Messina", "Sanmarcodalunzio", "Troinia", "Cataratti", "Torregrota"], "culture": "greek"}, "Shetland": {"settlements": ["Yell", "Tingwall", "Cunningsburgh", "Sumburgh", "Scalloway", "Northmavine", "Sound", "Muness"], "culture": "pictish"}, "Palermo": {"settlements": ["Palermo", "Monreale", "Misilmeri", "Petralia", "Caltavuturo", "Gratteri", "Mistretta"], "culture": "greek"}, "Trapani": {"settlements": ["Mazara", "Alcarno", "Trapani", "Erice", "Marsala", "Castelvertrano"], "culture": "greek"}, "Agrigento": {"settlements": ["Agricento", "Gela", "Licata", "Caltabellotta", "Butera", "Raffadali", "Montallegro"], "culture": "greek"}, "Siracusa": {"settlements": ["Syracusa", "Paterno", "Caltagirone", "Augusta", "Centuripe", "Noto", "Lentini"], "culture": "greek"}, "Taranto": {"settlements": ["Montepeloso", "Gravina", "Tricanico", "Mottola", "Castellaneta", "Taranto", "Cassano", "Tursi"], "culture": "greek"}, "Lecce": {"settlements": ["Ligento", "Lecce", "Leuca", "Oria", "Castro", "Andrano", "Brindisi", "Otranto"], "culture": "greek"}, "Bari": {"settlements": ["Bari", "Molietta", "Andria", "Giovinazzo", "Bitonto", "Conversano", "Ruvo", "Polignano"], "culture": "lombard"}, "Apulia": {"settlements": ["Lucano", "Barletta", "Lavello", "Salapia", "Cannae", "Trani", "Melfi", "Minervo"], "culture": "lombard"}, "Foggia": {"settlements": ["Bovino", "Termoli", "Vieste", "Siponto", "Salapla", "Foggia", "Lucera", "Troia"], "culture": "lombard"}, "Spoleto": {"settlements": ["Assisi", "Todi", "Perugia", "Spoleto", "Nursia", "Valva"], "culture": "lombard"}, "Innse Gall": {"settlements": ["Finlaggan", "Dunvegan", "Snizort", "Dunyveg", "Laggan", "Iona", "Uig", "Stornoway"], "culture": "irish"}, "Ancona": {"settlements": ["Osimo", "Pesaro", "Recanati", "Fermo", "Ancona", "Rimini", "Matelica", "Camerino"], "culture": "italian"}, "Ravenna": {"settlements": ["Ravenna", "Cesena", "Gatteo", "Alfonsine", "Cervia", "Cesenatico", "Gambettola", "Russi"], "culture": "italian"}, "Bologna": {"settlements": ["Bentivoglio", "Bologna", "Forli", "Budno", "Bagnacavallo", "Castelguelfo", "Faenza", "Imola"], "culture": "italian"}, "Ferrara": {"settlements": ["Bondeno", "Tresigallo", "Ferrara", "Codigoro", "Voghiera", "Occhiobello", "Commacchio", "Copparo"], "culture": "italian"}, "Mantua": {"settlements": ["Virgilio", "Bagnolosanvito", "Gonzaga", "Serravalle", "Marmirolo", "Curtatone", "Mantua", "Castellucchio"], "culture": "italian"}, "Padova": {"settlements": ["Vigonza", "Polesine", "Padova", "Este", "Rovigo", "Adria", "Montagnana", "Chioggia"], "culture": "italian"}, "Venezia": {"settlements": ["Murano", "Torcello", "Jesolo", "Pallestrina", "Venezia", "Rialto", "Fusina", "Lido"], "culture": "italian"}, "Treviso": {"settlements": ["Asola", "Oderzo", "Paese", "Ceneda", "Treviso", "Citadella", "Bassano", "Castelfranco"], "culture": "lombard"}, "Aquileia": {"settlements": ["Friuli", "Aquileia", "Udine", "Motta", "Concordia", "Ciridale", "Sacile", "Portoguaro"], "culture": "lombard"}, "Innsbruck": {"settlements": ["Kitzbuhel", "Schwaz", "Jenbach", "Kufstein", "Lienz", "Stams", "Innsbruck"], "culture": "german"}, "Orkney": {"settlements": ["Wyre", "Sanday", "Ronaldsay", "Egilsay", "Birsay", "Orphir", "Kirkwall", "Westray"], "culture": "pictish"}, "Oberbayern": {"settlements": ["Dingolfing", "Freising", "Ebersberg", "Diessen", "Pfaffenberg", "Andechs", "Munchen", "Dachau"], "culture": "german"}, "Niederbayern": {"settlements": ["Kirchroth", "Cham", "Ingolstadt", "Landshut", "Rohrbach", "Regensburg", "Wittelsbach"], "culture": "german"}, "Domazlice": {"settlements": ["Domazlice", "Kladruby", "Pisek", "Goldenkron", "Budejovice", "Rosenberg", "Hohenfurth", "Sobeslav"], "culture": "bohemian"}, "Litomerice": {"settlements": ["Osek", "Ceskalipa", "Usti", "Zatec", "Duchcov", "Chomutov", "Kadan", "Jachymov"], "culture": "bohemian"}, "Lausitz": {"settlements": ["Forst", "Cottbus", "Zittau", "Gorlitz", "Luckau", "Rothenburg", "Lebus"], "culture": "pommeranian"}, "Brandenburg": {"settlements": ["Belzig", "Ruppin", "Havelberg", "Juterborg", "Brandenburg", "Berlin", "Muncheberg", "Oranienburg"], "culture": "pommeranian"}, "Stettin": {"settlements": ["Kolbatz", "Soldin", "Wollin", "Kammin", "Pyritz", "Stettin", "Stestargard", "Cedene"], "culture": "pommeranian"}, "Slupsk": {"settlements": ["Colberg", "Rugenwalde", "Schlawe", "Dramburg", "Slupsk", "Ustka", "Tempelburg", "Belgard"], "culture": "pommeranian"}, "Danzig": {"settlements": ["Danlauenburg", "Mewe", "Schwetz", "Tuchel", "Schlochau", "Bytow", "Oliva", "Danzig"], "culture": "pommeranian"}, "Chelminskie": {"settlements": ["Chelmno", "Thorn", "Eylau", "Briesen", "Lobau", "Niedenburg", "Rehden", "Kulm"], "culture": "prussian"}, "Caithness": {"settlements": ["Dornoch", "Latheron", "Wick", "Dunbeath", "Freswick", "Thurso", "Golspie", "Dunrobin"], "culture": "pictish"}, "Marienburg": {"settlements": ["Braunsberg", "Bartenstein", "Balga", "Christburg", "Marienburg", "Heilsberg", "Marienwerder", "Elbing"], "culture": "prussian"}, "Sambia": {"settlements": ["Fischhausen", "Labiau", "Sambrandenburg", "Frombork", "Wiskiauten", "Cranz", "Konigsberg", "Tapiau"], "culture": "prussian"}, "Memel": {"settlements": ["Dreverna", "Memel", "Juodkrante", "Kaup", "Palanga", "Nida", "Kretingale", "Gargzdai"], "culture": "lithuanian"}, "Kurs": {"settlements": ["Duvzare", "Piltene", "Vanemane", "Ventava", "Ceklis", "Grobin", "Megava", "Bandava"], "culture": "lettigallish"}, "Zemigalians": {"settlements": ["Selpils", "Cruczeborch", "Riga", "Remigala", "Jelgava", "Bauska", "Mezotne", "Skaistkalne"], "culture": "lettigallish"}, "Lettigalians": {"settlements": ["Kokenois", "Lemisele", "Gaujiena", "Seswegen", "Wenden", "Wolmer", "Uxkull"], "culture": "ugricbaltic"}, "Osel": {"settlements": ["Valjala", "Leisi", "Kaarma", "Muhu", "Poide", "Kuressare", "Hiiumaa", "Orisaare"], "culture": "ugricbaltic"}, "Livs": {"settlements": ["Parnu", "Lihula", "Salaspils", "Haapsalu"], "culture": "ugricbaltic"}, "Reval": {"settlements": ["Pades", "Toompea", "Leal", "Hapsal", "Laane", "Reval", "Borpeal", "Parnaw"], "culture": "ugricbaltic"}, "Dorpat": {"settlements": ["Odenpah", "Kirrumpa", "Vastseliina", "Fellin", "Jarva", "Vanakastre", "Lais", "Tartu"], "culture": "ugricbaltic"}, "Teviotdale": {"settlements": ["Maxwell", "Jedburgh", "Ednam", "Roxburgh", "Kelso", "Selkirk", "Peebles", "Melrose"], "culture": "saxon"}, "Narva": {"settlements": ["Wesenberg", "Telsborg", "Alentagh", "Agelinde", "Repel", "Narva", "Pudiviru", "Askala"], "culture": "ugricbaltic"}, "Nyland": {"settlements": ["Raseborg", "Hanko", "Lohja", "Porvoo", "Siuntio", "Espoo", "Svartholm", "Helsinge"], "culture": "finnish"}, "Finland": {"settlements": ["Naantali", "Turku", "Rauma", "Jukarsborg", "Stenberga", "Rikala", "Lieto", "Kuusisto"], "culture": "finnish"}, "Tavasts": {"settlements": ["Haikonen", "Lahti", "Mattila", "Vesilahti", "Vanaja", "Harviala", "Hameenlinna", "Hattula"], "culture": "finnish"}, "Satakunta": {"settlements": ["Hahlo", "Kiukainen", "Kankaanpaa", "Liinmaa", "Hiittenharju", "Pori", "Ulvila", "Telja"], "culture": "finnish"}, "Osterbotten": {"settlements": ["Oulu", "Jakobstad", "Veteli", "Liminka", "Kalajoki", "Nykarleby", "Korsholm"], "culture": "finnish"}, "Kemi": {"settlements": ["Neiden", "Rovaniemi", "Kemijarvi", "Savukoski", "Utsjoki", "Inari", "Tornio"], "culture": "lappish"}, "Kola": {"settlements": ["Jekanskoi", "Tre", "Pechenga", "Lovozero", "Waranger", "Molovskoi", "Mafelskoi"], "culture": "lappish"}, "Karelen": {"settlements": ["Kalevala", "Soroka", "Loukhi", "Sordavala", "Kem", "Kostomuksha", "Muezersky", "Pitkyaranta"], "culture": "finnish"}, "Finnmark": {"settlements": ["Malangen", "Hammerfest", "Ostervagen", "Piselvnes", "Tromso", "Vardohus", "Karsloy"], "culture": "lappish"}, "Ross": {"settlements": ["Rosemarkie", "Cromarty", "Tain", "Dingwall", "Avoch", "Fortrose", "Applecross", "Fearn"], "culture": "pictish"}, "Savolaks": {"settlements": ["Sysma", "Kuopio", "Savitaipale", "Sotkamo", "Mikkeli", "Brahelinna", "Olavinlinna", "Iisalmi"], "culture": "finnish"}, "Nordland": {"settlements": ["Narvik", "Kabelvag", "Bodo", "Rodoy", "Harstad", "Rost", "Andenes", "Beiarn"], "culture": "norse"}, "Kexholm": {"settlements": ["Jekaborg", "Raivola", "Antrea", "Taipale", "Toksovo", "Koivisto", "Kakisalmi", "Terijoki"], "culture": "finnish"}, "Onega": {"settlements": ["Ust-Onega", "Segezha", "Pryazha", "Aunus", "Petrozavodsk", "Pudoga", "Kondopoga"], "culture": "finnish"}, "Trans-Portage": {"settlements": ["Nyandoma", "Konosha", "Plesetsk", "Obozerskiy", "Samoded", "Shenkursk", "Solovetsky"], "culture": "finnish"}, "North Dvina": {"settlements": ["Solvychegodsk", "Antonievosiysky", "Archangelsk", "Usolsk", "Novokholmogory", "Koryazhma", "Nikolokorelski"], "culture": "samoyed"}, "Bjarmia": {"settlements": ["Kamenka", "Mezen", "Kusnezowa", "Kimzha", "Pinega", "Lampozhnya", "Okulovsky"], "culture": "samoyed"}, "Samoyeds": {"settlements": ["Sukhanikha", "Vizhas", "Chizha", "Tarasova", "Arkhipovo", "Yazhma", "Kiya"], "culture": "samoyed"}, "Ugra": {"settlements": ["Yarega", "Vodnyy", "Kadzherom", "Nizhodes", "Sosnogorsk", "Vuktyl", "Voyvozh"], "culture": "samoyed"}, "Syrj": {"settlements": ["Emva", "Pyras", "Yugydyag", "Ezhva", "Zheshart", "Mikun", "Sindor"], "culture": "samoyed"}, "Tyrone": {"settlements": ["Derry", "Tullyhogue", "Omagh", "Coleraine", "Dungannon", "Maghera", "Dungiven", "Aileach"], "culture": "irish"}, "Moray": {"settlements": ["Forres", "Kinloss", "Urquhart", "Inverness", "Lochindorb", "Cawdor", "Elgin", "Nairn"], "culture": "pictish"}, "Zyriane": {"settlements": ["Lek", "Kukushtan", "Suksun", "Kordon", "Posad", "Gari", "Ergach"], "culture": "samoyed"}, "Hlynov": {"settlements": ["Izkar", "Kambarka", "Mozjga", "Sarapul", "Egra", "Glazkar", "Wotka"], "culture": "mordvin"}, "Veliky Ustug": {"settlements": ["Pinyug", "Maromitsa", "Gleden", "Oparino", "Podosinovets", "Krasavino", "Luza"], "culture": "samoyed"}, "Romny": {"settlements": ["Ugol", "Vysokaya", "Bykovskaya", "Kholuy", "Vozhega", "Yuchka", "Marinskaya"], "culture": "finnish"}, "Zaozerye": {"settlements": ["Nazankha", "Afoninskaya", "Bolshaya", "Konechnaya", "Borisovskaya", "Zarechnaya", "Pashuchikha", "Kharovsk"], "culture": "finnish"}, "Chud": {"settlements": ["Zalese", "Zaytsevo", "Krbor", "Veldvor", "Chunlovka", "Krutayaosyp", "Kamchuga"], "culture": "finnish"}, "Vologda": {"settlements": ["Motyn", "Bolshayamurga", "Dvinitsa", "Sokol", "Staroye", "Kadnikovskaya"], "culture": "finnish"}, "Kostroma": {"settlements": ["Zavolzhsk", "Nerektha", "Kosmynino", "Nekrasoskoye", "Sudislavl", "Apraksino", "Plyos"], "culture": "mordvin"}, "Beloozero": {"settlements": ["Fedosyevo", "Khoklovo", "Babayevo", "Glushkovo", "Kirillobelozersky", "Kinilov", "Kaduy"], "culture": "finnish"}, "Bezhetsky Verh": {"settlements": ["Rameshki", "Obrosovo", "Bezhetsk", "Maksatikha", "Spasnakholmu", "Molokovo", "Sonkovo", "Kyasovagora"], "culture": "ilmenian"}, "Buchan": {"settlements": ["Aberdeen", "Banff", "Kintore", "Ellon", "St Machar", "Inverurie", "Fyvie", "Deer"], "culture": "pictish"}, "Toropets": {"settlements": ["Dno", "Valday", "Toropets", "Staryarussa", "Kresttsy", "Lychkovo", "Demyansk", "Shimsk"], "culture": "ilmenian"}, "Vodi": {"settlements": ["Liivtsula", "Valaam", "Khotchino", "Ivanovskaya", "Nosok", "Nyen", "Jogopera", "Noteborg"], "culture": "ugricbaltic"}, "Torzhok": {"settlements": ["Kingisepp", "Vistino", "Vassakara", "Yamskygorodok", "Shcheremenski", "Volosovo", "Komarovka", "Konnovo"], "culture": "ilmenian"}, "Pskov": {"settlements": ["Pskov", "Pechory", "Dedovichi", "Svyatogorki", "Gdov", "Soltchi", "Ostrov", "Porkhov"], "culture": "ugricbaltic"}, "Novgorod": {"settlements": ["Borovichi", "Okulovka", "Chudovo", "Boldorki", "Luga", "Pestovo", "Novgorod"], "culture": "ilmenian"}, "Velikiye Luki": {"settlements": ["Bely", "Usvyaty", "Opochka", "Velikiyeluki", "Sebezh", "Nevel", "Staryatoropa", "Loknya"], "culture": "ilmenian"}, "West Dvina": {"settlements": ["Ludza", "Balvi", "Varakjani", "Rezekne", "Erle", "Daugavpils", "Vilaka", "Jersika", "Kraslava", "Kreuzburg"], "culture": "lettigallish"}, "Vitebsk": {"settlements": ["Stryzhava", "Drazdy", "Baroniki", "Vitebsk", "Ruba", "Liozno", "Haradok", "Sakolniki"], "culture": "ilmenian"}, "Orsha": {"settlements": ["Kopys", "Orsha", "Sianno", "Talachyn", "Horki", "Larynouka", "Novolukomi"], "culture": "ilmenian"}, "Polotsk": {"settlements": ["Polotsk", "Pastavy", "Miory", "Myadzel", "Dzisna", "Braslaw", "Rasony"], "culture": "ilmenian"}, "Strathearn": {"settlements": ["Crieff", "Dunblane", "Doune", "Auchterarder", "Tullibardine", "Inchaffray", "Kenmore", "Madderty"], "culture": "pictish"}, "Aukshayts": {"settlements": ["Kernave", "Kreva", "Kaunas", "Zirmunai", "Vilnius", "Utena", "Bralaus", "Lida"], "culture": "lithuanian"}, "Zhmud": {"settlements": ["Raseiniai", "Kraziai", "Jurbarkas", "Panemune", "Taurage", "Upyte", "Varviai", "Joniskis"], "culture": "lithuanian"}, "Scalovia": {"settlements": ["Jomsberg", "Jurgaiten", "Splitter", "Skomanten", "Strewa", "Ragnit", "Russ"], "culture": "prussian"}, "Sudovia": {"settlements": ["Trakai", "Augustavas", "Seiniai", "Merkine", "Raiziai", "Suvalkai", "Hrodna", "Vilkaviskis"], "culture": "lithuanian"}, "Jacwiez": {"settlements": ["Grodno", "Iuje", "Jacwiez", "Zirmuny", "Niasvizh", "Mir", "Slonim", "Novogrudok"], "culture": "lithuanian"}, "Podlasie": {"settlements": ["Zambrow", "Lapy", "Lomza", "Krynki", "Sejny", "Drohiczyn", "Kolno", "Tykocin"], "culture": "lithuanian"}, "Yatvyagi": {"settlements": ["Johannisburg", "Lyck", "Valkininkai", "Druskininkai", "Yatvarena", "Lotzen", "Eckersberg"], "culture": "lithuanian"}, "Galindia": {"settlements": ["Treuburg", "Hohenstein", "Gilgenburg", "Angerburg", "Neidenburg", "Nikelshagen", "Wielbark", "Osterode"], "culture": "prussian"}, "Kujawy": {"settlements": ["Bydgoszcz", "Inowroclaw", "Kruszwica", "Topolka", "Wlocawek", "Lubanie", "Radziejow", "Brzesckujawskie"], "culture": "polish"}, "Gnieznienskie": {"settlements": ["Wyszo", "Znin", "Lekno", "Naklo", "Wagrowiec", "Pyzdry", "Giecz", "Gniezno"], "culture": "polish"}, "Gowrie": {"settlements": ["Dundee", "Scone", "Errol", "Forteviot", "Perth", "Abernethy", "Dunkeld", "Clunie"], "culture": "pictish"}, "Lubusz": {"settlements": ["Kostrzyn", "Mysliborz", "Cedynia", "Zielonagora", "Sulecin", "Lubusz", "Santok", "Pryzyce"], "culture": "polish"}, "Poznanskie": {"settlements": ["Poznan", "Strarygrode", "Srem", "Obrzycko", "Zbaszyn", "Czarkow", "Drzen", "Miedryrzecz"], "culture": "polish"}, "Kaliskie": {"settlements": ["Kalisz", "Jarocin", "Ostrowielkopolski", "Tureck", "Krotoszyn", "Rawick", "Pieszew", "Konin"], "culture": "polish"}, "Opole": {"settlements": ["Czestochowa", "Opole", "Namyslow", "Strzelce", "Olezno", "Raciborz", "Lelow", "Kozle"], "culture": "polish"}, "Lower Silesia": {"settlements": ["Krosno", "Jawor", "Legnica", "Glogow", "Boleslawiec", "Lwowek", "Swidnica"], "culture": "polish"}, "Upper Silesia": {"settlements": ["Zmigrod", "Olesnica", "Nysa", "Wroclaw", "Brzeg", "Henrykow", "Niemcza", "Milicz"], "culture": "polish"}, "Boleslav": {"settlements": ["Turnov", "Jaromer", "Trutnov", "Kamieniec", "Hradiste", "Jicin", "Glatz", "Nachod"], "culture": "bohemian"}, "Praha": {"settlements": ["Karlstein", "Praha", "Kuttenberg", "Kolin", "Brevnov", "Stare Mesto", "Zbraslav", "Slany"], "culture": "bohemian"}, "Hradec": {"settlements": ["Pardubice", "Zamberk", "Chrudim", "Hradeckralove", "Pelhrimov", "Policka", "Litomysl", "Jihlava"], "culture": "bohemian"}, "Plzen": {"settlements": ["Tachov", "Susice", "Stribo", "Cheb", "Plasy", "Plzen", "Rokycany", "Pomuk"], "culture": "bohemian"}, "Atholl": {"settlements": ["Pitlochry", "Fortingall", "Grandtully", "Anthrachs", "Strathardle", "Rannoch", "Glen Dochart", "Blair Atholl", "Struan"], "culture": "pictish"}, "Olomouc": {"settlements": ["Ostrava", "Zdar", "Opava", "Unicov", "Olomouc", "Moravskatrebova", "Sternberk", "Zabreh"], "culture": "bohemian"}, "Brno": {"settlements": ["Boskovice", "Kromeriz", "Uherskehradiste", "Velehrad", "Wisowitz", "Prerov", "Zlin", "Uherskebrod"], "culture": "bohemian"}, "Trencin": {"settlements": ["Congsberg", "Puho", "Turoc", "Ban", "Illava", "Trencsen", "Povazskabystrica", "Zilina"], "culture": "bohemian"}, "Nitra": {"settlements": ["Zabokreky", "Preuigan", "Galgoc", "Postyen", "Nagytapolcsany", "Nyitra", "Stbenedek", "Nagysurany"], "culture": "bohemian"}, "Esztergom": {"settlements": ["Kakath", "Nagyigmand", "Nemesocsa", "Esztergom", "Komarom", "Gyorszentmarton", "Tatabanya", "Ogylla"], "culture": "avar"}, "Pressburg": {"settlements": ["Szentgyorgy", "Pressburg", "Dunaszerdahely", "Somorja", "Nagyszombat", "Bazin", "Modor", "Galanta"], "culture": "bohemian"}, "Znojmo": {"settlements": ["Eibenshitz", "Ivancice", "Mikulov", "Iglau", "Znojmo", "Trebic", "Lundenburg", "Skalitz"], "culture": "bohemian"}, "Passau": {"settlements": ["Formbach", "Ortenburg", "Schaumberg", "Raab", "Freyung", "Passau", "Freistadt", "Ulrichsberg"], "culture": "german"}, "Salzburg": {"settlements": ["Salzburg", "Durmberg", "Gastein", "Berchtesgaden", "Muhldorf", "Tittmoning", "Laufen", "Waging"], "culture": "german"}, "Osterreich": {"settlements": ["Hohenwarth", "Wien", "Linz", "Melk", "Steyr", "Stpolten", "Krems", "Wagram"], "culture": "german"}, "Argyll": {"settlements": ["Sween", "Argh", "Dunollie", "Loch Awe", "Kilmun", "Dunstaffnage", "Inverary", "St Moluag", "Ardchattan"], "culture": "irish"}, "Sopron": {"settlements": ["Gyor", "Csepreg", "Sopron", "Nagymarton", "Csorna", "Borsmonostor", "Kismarton", "Kapuvar"], "culture": "croatian"}, "Fejer": {"settlements": ["Adony", "Szekszard", "Val", "Dombovar", "Tamasi", "Sarbogard", "Bonyhad", "Mor"], "culture": "avar"}, "Pecs": {"settlements": ["Kalocsa", "Szentlorinc", "Darda", "Pecsvarad", "Mohacs", "Sasd", "Pecs", "Siklos"], "culture": "avar"}, "Szekezfehervar": {"settlements": ["Nagyatad", "Lengyeltoti", "Szigetvar", "Marcali", "Szekezfehervar", "Barcs", "Kaposvar", "Csurgo"], "culture": "avar"}, "Vas": {"settlements": ["Nemetujvar", "Koszeg", "Szentgotthard", "Sarvar", "Kormend", "Celldomolk", "Szombathely", "Vasvar"], "culture": "croatian"}, "Steiermark": {"settlements": ["Seckau", "Graz", "Lavant", "Leibnitz", "Radkersburg", "Stubing", "Cilli", "Eppenstein"], "culture": "german"}, "Karnten": {"settlements": ["Laibach", "Villach", "Sann", "Treffen", "Klagenfurt", "Ossiach", "Pettau"], "culture": "croatian"}, "Krain": {"settlements": ["Gorz", "Zerknitz", "Stveit", "Gurk", "Krainburg", "Guetenegg", "Auersperg", "Stain"], "culture": "croatian"}, "Istria": {"settlements": ["Lovrana", "Mitterburg", "Trieste", "Pula", "Karstberg", "Wolauska", "Fiume", "Duino"], "culture": "croatian"}, "Veglia": {"settlements": ["Crikvenica", "Bakar", "Krk", "Veglia", "Cres", "Kraljevica", "Vrbovsko", "Frankopan"], "culture": "croatian"}, "Fife": {"settlements": ["Leuchars", "Kinross", "Cupar", "Lochore", "St Andrews", "Dunfermline", "Kirkcaldy", "Falkland"], "culture": "pictish"}, "Varadzin": {"settlements": ["Ludbreg", "Krapina", "Oroslavje", "Varazdin", "Cakovec", "Donjastubica", "Lepoglava", "Toplice"], "culture": "croatian"}, "Zagreb": {"settlements": ["Sisak", "Karlovac", "Zrin", "Zagreb", "Cetin", "Dreznik", "Ozalj"], "culture": "croatian"}, "Krizevci": {"settlements": ["Koprivnica", "Durdevac", "Pozega", "Krizevci", "Vinkovci", "Vukovar", "Virovitica", "Osijek"], "culture": "croatian"}, "Usora": {"settlements": ["Blagaj", "Usora", "Kuljc", "Banjaluka", "Jajce", "Bihac", "Bocac", "Prijedor"], "culture": "croatian"}, "Senj": {"settlements": ["Udbina", "Karlobag", "Donjilapac", "Brinje", "Kaseg", "Otocac", "Senj"], "culture": "croatian"}, "Zadar": {"settlements": ["Obrovac", "Sibenik", "Novigrad", "Knin", "Benkovac", "Nin", "Zadar", "Pag"], "culture": "croatian"}, "Zachlumia": {"settlements": ["Sirokibrijeg", "Drvar", "Neretva", "Livno", "Ljubuski", "Mostar", "Capljina", "Duvno"], "culture": "croatian"}, "Split": {"settlements": ["Trogir", "Split", "Klis", "Makarska", "Solin", "Imotski", "Sinj", "Hvar"], "culture": "croatian"}, "Ragusa": {"settlements": ["Ragusa", "Cavtat", "Mljet", "Kolocep", "Slano", "Narona", "Sipan"], "culture": "serbian"}, "Zeta": {"settlements": ["Bar", "Budva", "Danj", "Drivast", "Podgorica", "Ulcinj", "Skadar", "Kotor"], "culture": "serbian"}, "Clydesdale": {"settlements": ["Cadzow", "Lesmahagow", "Lanark", "Bothwell", "St Kentigern", "Renfrew", "Dumbarton", "Glasgow"], "culture": "welsh"}, "Dyrrachion": {"settlements": ["Chounavia", "Kruje", "Spinarizza", "Valona", "Durazzo", "Elbasan", "Beat", "Geziq"], "culture": "greek"}, "Ochrid": {"settlements": ["Tomot", "Bitola", "Ohrid", "Krusevo", "Svetigrad", "Kicevo", "Debar", "Kastoria"], "culture": "serbian"}, "Epeiros": {"settlements": ["Igoumenitsa", "Sagiada", "Sopot", "Paramythia", "Butrint", "Gjirokaster", "Ioannina", "Pogonia"], "culture": "greek"}, "Arta": {"settlements": ["Angelokastron", "Preveza", "Thomokastron", "Vonitsza", "Arta", "Rogoi", "Vlacherna", "Agnanta"], "culture": "greek"}, "Cephalonia": {"settlements": ["Zante", "Lefkas", "Ithaca", "Cerigo", "Palaiofrourio", "Paxos", "Kefalonia"], "culture": "greek"}, "Hellas": {"settlements": ["Markrynia", "Amphissa", "Amfissa", "Lidoriki", "Kastrinitsi", "Paravola", "Naupaktos"], "culture": "greek"}, "Achaia": {"settlements": ["Andravida", "Pyrgos", "Karditza", "Chalandritza", "Patras", "Akova", "Kalavryta", "Geraki"], "culture": "greek"}, "Methone": {"settlements": ["Kiparissia", "Coron", "Kalamata", "Gritzena", "Karytaina", "Pilos", "Modon", "Androusa"], "culture": "greek"}, "Monemvasia": {"settlements": ["Gythio", "Lacedaemonia", "Elos", "Monemvasia", "Mistra", "Arkadia", "Nikli", "Sparta"], "culture": "greek"}, "Kaneia": {"settlements": ["Matala", "Nikiforosfokas", "Kastellikissamos", "Paleohora", "Arkadi", "Kandia", "Rethymno", "Akrotin"], "culture": "greek"}, "Lothian": {"settlements": ["Linlithgow", "Torphichen", "Falkirk", "Edinburgh", "Leith", "Stirling", "Abercorn", "Stow Of Wedale"], "culture": "welsh"}, "Chandax": {"settlements": ["Ierapetra", "Agiosnikolaos", "Knossos", "Kastelli", "Iraklio", "Sitia", "Malia", "Lassithi"], "culture": "greek"}, "Korinthos": {"settlements": ["Corinth", "Veligosti", "Nauplion", "Vostitza", "Zemenos", "Megapoli", "Argos", "Passava"], "culture": "greek"}, "Atheniai": {"settlements": ["Marathon", "Karydi", "Megara", "Athens", "Salamis", "Soula", "Daphni"], "culture": "greek"}, "Rhodos": {"settlements": ["Karpathos", "Kos", "Ialysos", "Rhodos", "Lindos", "Pefkos", "Koskinou", "Haraki"], "culture": "greek"}, "Naxos": {"settlements": ["Tinos", "Hermoupolis", "Mykonos", "Filoti", "Santorini", "Andros", "Naxos", "Kastraki"], "culture": "greek"}, "Euboia": {"settlements": ["Istiaia", "Lilantia", "Messapia", "Kymi", "Chalkis", "Oreoi", "Artemisio", "Karystos"], "culture": "greek"}, "Chios": {"settlements": ["Fourni", "Pagondas", "Marathokampos", "Chios", "Tigani", "Chrysostomos", "Samos", "Ikaria"], "culture": "greek"}, "Lesbos": {"settlements": ["Agiasos", "Eresos", "Mytilene", "Kalloni", "Mithymna", "Moudros", "Thasos", "Plomari"], "culture": "greek"}, "Demetrias": {"settlements": ["Gravia", "Ravennika", "Levadhia", "Boudonitza", "Neopatras", "Demetrias", "Lebadea", "Thebes"], "culture": "greek"}, "Thessalia": {"settlements": ["Larissa", "Damasis", "Neopetra", "Trikkala", "Stagi", "Volos", "Kastri", "Pharsalos"], "culture": "greek"}, "Carrick": {"settlements": ["Greenan", "Ballantrae", "Turnberry", "Loch Doon", "Culzean", "Crossraguel", "Maybole", "Dunure"], "culture": "welsh"}, "Thessalonike": {"settlements": ["Hlerin", "Servia", "Thessaloniki", "Voden", "Elasson", "Cemren", "Veria"], "culture": "greek"}, "Chalkidike": {"settlements": ["Melnik", "Mntathos", "Zicna", "Drama", "Chrysiopolis", "Philippi", "Serres", "Siderokastron"], "culture": "greek"}, "Strymon": {"settlements": ["Kocane", "Strumica", "Trikves", "Prosek", "Kratovo", "Skopje", "Veles", "Prilep"], "culture": "serbian"}, "Philippopolis": {"settlements": ["Anaktoropolis", "Klokoknitsa", "Peritheorion", "Polystylon", "Prodromos", "Mosynopolis", "Philippopolis", "Xantheia"], "culture": "greek"}, "Adrianopolis": {"settlements": ["Traianopolis", "Berat", "Didymoteichon", "Ainos", "Kypsela", "Demotika", "Adrianopolis", "Skalothe"], "culture": "greek"}, "Kaliopolis": {"settlements": ["Sestus", "Madyta", "Rhaidestos", "Gallipoli", "Lysimachia", "Panidos", "Selymbria", "Heraclea"], "culture": "greek"}, "Byzantion": {"settlements": ["Galata", "Vlanga", "Pempton", "Blachernae", "Deuteron", "Hieron", "Constantinople", "Hagiasophia"], "culture": "greek"}, "Thrake": {"settlements": ["Sestos", "Chariopolis", "Verissa", "Deleus", "Syrallum", "Aulaeitichus", "Phinopolis", "Salmydessus"], "culture": "greek"}, "Mesembria": {"settlements": ["Mesembria", "Anchilios", "Sozopolis", "Aetos", "Odessos", "Varna", "Bourgas", "Valchidol"], "culture": "bulgarian"}, "Tyrnovo": {"settlements": ["Irinopolis", "Opan", "Tyrnovo", "Maglizh", "Kazanlak", "Hisarya", "Chirpan", "Kilifarevski"], "culture": "bulgarian"}, "Ulster": {"settlements": ["Dunluce", "Carrickfergus", "Downpatrick", "Bangor", "Connor", "Larne", "Dromore", "Dunseverick"], "culture": "irish"}, "Galloway": {"settlements": ["Wigtown", "Threave", "Kirkcudbright", "Whithorn", "Dunragit", "Glenluce", "Dunrod", "Dumfries"], "culture": "welsh"}, "Serdica": {"settlements": ["Velbazhd", "Rila", "Pravets", "Pernik", "Serdica", "Breznik", "Samundzhievo", "Etropole"], "culture": "serbian"}, "Naissus": {"settlements": ["Knjazevac", "Kumanovo", "Vranje", "Nish", "Lesnovo", "Koprijan", "Brdo", "Kambelevac"], "culture": "romanian"}, "Rashka": {"settlements": ["Polog", "Dioclea", "Trepca", "Zvecan", "Prizren", "Decani", "Svetispas", "Djakovica"], "culture": "serbian"}, "Hum": {"settlements": ["Novipazar", "Pec", "Moraca", "Plav", "Stupovi", "Medun", "Bradarevo", "Belacrkva"], "culture": "serbian"}, "Rama": {"settlements": ["Srebrenica", "Borac", "Srebrnik", "Zvornik", "Usice", "Samobor", "Zenica", "Rama"], "culture": "serbian"}, "Belgrade": {"settlements": ["Branicevo", "Zemun", "Belgrade", "Lipovic", "Pozarevac", "Smederevo", "Rudnik", "Kragujevac"], "culture": "serbian"}, "Vidin": {"settlements": ["Pirot", "Zajecar", "Kucevo", "Viseslav", "Kula", "Vidin", "Srvljig", "Bolvan"], "culture": "romanian"}, "Nikopolis": {"settlements": ["Knezha", "Iskar", "Nikopolis", "Pleven", "Belene", "Oescus", "Dolnidabknik", "Pordim"], "culture": "bulgarian"}, "Dorostotum": {"settlements": ["Slivopole", "Byaladve", "Tsenovo", "Dorosturum", "Samuil", "Shumen", "Rusi", "Borovo"], "culture": "bulgarian"}, "Karvuna": {"settlements": ["Prezlav", "Varbitsz", "Kaliakra", "Venets", "Karvuna", "Silistria", "Smyadovo", "Dobrich"], "culture": "bulgarian"}, "Dunbar": {"settlements": ["Berwick", "Coldingham", "Crichton", "Dunbar", "Tyninghame", "Huntly", "Thirlestane", "Gordon"], "culture": "welsh"}, "Constantia": {"settlements": ["Cobadin", "Mesgidia", "Adamclisi", "Constantia", "Topraisar", "Cogealac", "Carachioi", "Mangalia"], "culture": "bulgarian"}, "Galaz": {"settlements": ["Sulina", "Macin", "Galaz", "Vicina", "Isaccea", "Tulcea", "Crisan", "Aegyssus"], "culture": "avar"}, "Belgorod": {"settlements": ["Chilia", "Palada", "Falciu", "Tigheci", "Oblucita", "Scheia", "Belgorod", "Oancea"], "culture": "avar"}, "Birlad": {"settlements": ["Barlad", "Tecuci", "Vaslui", "Braila", "Galati", "Ramnicusarat", "Buzau"], "culture": "avar"}, "Turnu": {"settlements": ["Bucuresti", "Giurgiu", "Rosiorriidevede", "Oltenita", "Turnu", "Dristra", "Corabia", "Strehaia"], "culture": "avar"}, "Tirgoviste": {"settlements": ["Curteadearges", "Targoviste", "Ploiesti", "Calimanesti", "Campulung", "Poenari", "Pitesti", "Cotmeana"], "culture": "avar"}, "Severin": {"settlements": ["Ursova", "Bals", "Slatina", "Craiova", "Ramnic", "Caracal", "Tirgujiu", "Severin"], "culture": "romanian"}, "Temes": {"settlements": ["Versecz", "Lugos", "Detta", "Temesvar", "Buzias", "Csak", "Kevevara", "Karansebes"], "culture": "avar"}, "Bacs": {"settlements": ["Apatin", "Pardany", "Zombor", "Szintarev", "Bacsalmas", "Bacs", "Baja", "Pancsova"], "culture": "avar"}, "Feher": {"settlements": ["Feher", "Abrudbanya", "Vizakna", "Tovis", "Elek", "Gyulafehervar", "Nagyenyed", "Arad"], "culture": "avar"}, "Northumberland": {"settlements": ["Norham", "Morpeth", "Alnwick", "Lindisfarne", "Mitford", "Newcastle", "Hexham", "Bamburgh"], "culture": "saxon"}, "Bihar": {"settlements": ["Elesd", "Nagybajom", "Bihar", "Nagyvarad", "Debrecen", "Szalard", "Biharkeresztes", "Zolonta"], "culture": "avar"}, "Csanad": {"settlements": ["Csongrad", "Battonya", "Hodmezovasarhely", "Mindszent", "Szentes", "Szeged", "Mako", "Csanad"], "culture": "avar"}, "Pest": {"settlements": ["Kiskunhalas", "Kiskoros", "Kecskemet", "Cegled", "Vac", "Pest", "Szentendre", "Abrahamtelke"], "culture": "avar"}, "Heves": {"settlements": ["Mezokovesd", "Hatvan", "Tiszafured", "Gyongyos", "Miskolc", "Heves", "Eger", "Petervasara"], "culture": "avar"}, "Gemer": {"settlements": ["Jolsva", "Nyustya", "Losonc", "Rozsnyo", "Balassagyarmat", "Gomor", "Dobsina", "Nagyroce"], "culture": "bohemian"}, "Orava": {"settlements": ["Nameszto", "Trsztena", "Arvavara", "Turdossin", "Rozsahegy", "Zolyom", "Nemetlipcse", "Liptovskymikulas"], "culture": "bohemian"}, "Cieszyn": {"settlements": ["Oswiecim", "Zebrydowice", "Ustron", "Bielskobiala", "Jabloskow", "Cieszyn", "Goleszow", "Skoczow"], "culture": "polish"}, "Krakowskie": {"settlements": ["Tarnow", "Kielce", "Chrzanow", "Skawina", "Brzesko", "Jedrzejow", "Olkusz", "Krakow"], "culture": "polish"}, "Sieradzko-Leczyckie": {"settlements": ["Radomsko", "Wachock", "Blaski", "Sochaczew", "Warta", "Leczyka", "Sieradz", "Piotrkow"], "culture": "polish"}, "Plock": {"settlements": ["Plock", "Wyszkow", "Ciechanow", "Warszawa", "Pultusk", "Pruszkow", "Plonsk", "Ostroleka"], "culture": "polish"}, "Cumberland": {"settlements": ["Penrith", "Dacre", "Gilsland", "Papcastlet", "Carlisle", "Burgh", "Egremont", "Cockermouth"], "culture": "saxon"}, "Czersk": {"settlements": ["Radom", "Siedlce", "Gorzno", "Grojec", "Borowie", "Losice", "Garwolin", "Czersk"], "culture": "polish"}, "Sandomierskie": {"settlements": ["Wilczyce", "Samborzec", "Loniow", "Sandomierz", "Zawichost", "Koprzywnica", "Klimontow", "Dwikozy"], "culture": "polish"}, "Sacz": {"settlements": ["Limanowa", "Gorlice", "Szczyrzycz", "Grybow", "Jasto", "Zakopane", "Nowysacz", "Brzozow"], "culture": "polish"}, "Saris": {"settlements": ["Lemesany", "Giralth", "Saris", "Eperjes", "Kisszeben", "Scyuidnyk", "Bartfa", "Hethars"], "culture": "croatian"}, "Peremyshl": {"settlements": ["Volkrosno", "Rzeszow", "Jaroslav", "Jaslo", "Sanok", "Peremyshl", "Grodek", "Lubaczow"], "culture": "volhynian"}, "Vladimir Volynsky": {"settlements": ["Luboml", "Hrubieszow", "Kholm", "Torchyn", "Cherven", "Kovel", "Vladimirvolynsky", "Ivanichy"], "culture": "volhynian"}, "Galich": {"settlements": ["Brody", "Dubno", "Vasyliv", "Galich", "Buzhsk", "Lvov", "Ternopil", "Kolomyia"], "culture": "volhynian"}, "Bereg": {"settlements": ["Kapos", "Beregszasz", "Munkacs", "Szobranc", "Ungvar", "Szolyva", "Ilosva", "Perecseny"], "culture": "croatian"}, "Abauj": {"settlements": ["Kassa", "Tokaj", "Szikszo", "Sarospatak", "Abauj", "Satoraljaujhely", "Szepsi", "Turna"], "culture": "croatian"}, "Marmaros": {"settlements": ["Aknasugatag", "Felsoviso", "Maramarossziget", "Nagybanya", "Nagykaroly", "Tecso", "Huszt", "Raho"], "culture": "avar"}, "Isle Of Man": {"settlements": ["Sulby", "Peel", "Kirk Michael", "Maughold", "Rushen", "Inis Patraic", "Laxey", "Douglas"], "culture": "welsh"}, "Szekelyfold": {"settlements": ["Maros", "Szekelyudvarhely", "Csik", "Aranyos", "Kezdi", "Marosvasarhely", "Sepsiszentgyorgy", "Haromszek"], "culture": "avar"}, "Peresechen": {"settlements": ["Varzaresti", "Baltile", "Iasi", "Harlau", "Chisinau", "Tutora", "Orhei", "Tuzara"], "culture": "hungarian"}, "Olvia": {"settlements": ["Causeni", "Alibei", "Cainari", "Cetateaalba", "Tighina", "Ophusia", "Olvia", "Basarabeasca"], "culture": "avar"}, "Oleshye": {"settlements": ["Balta", "Kocibey", "Odessa", "Sokoly", "Bohopol", "Akkerman", "Nikolayev", "Ochakiv"], "culture": "hungarian"}, "Korsun": {"settlements": ["Zolotonosha", "Cherkassy", "Zhuravky", "Smila", "Uman", "Mirov", "Kaniv", "Korsun"], "culture": "hungarian"}, "Torki": {"settlements": ["Suceava", "Torki", "Bogdana", "Cernauti", "Lipcani", "Siret", "Hotin"], "culture": "volhynian"}, "Terebovl": {"settlements": ["Borschiv", "Kremenets", "Vinnytsia", "Terebovl", "Buchach", "Zalischyky", "Bratslav", "Pochayivlavra"], "culture": "volhynian"}, "Kiev": {"settlements": ["Iskorosten", "Fastiv", "Yuriev", "Malyn", "Zhitomir", "Kiev", "Ovruch", "Vyshhorod"], "culture": "volhynian"}, "Pinsk": {"settlements": ["Kosava", "Stepan", "Porkhovo", "Dabuchin", "Pinsk", "Biaroza", "Lutsk", "Luninets"], "culture": "volhynian"}, "Beresty": {"settlements": ["Kobryn", "Lublin", "Bielsk", "Parczew", "Beresty", "Kamyanyets", "Wlodawa", "Mielnik"], "culture": "volhynian"}, "Westmorland": {"settlements": ["Appleby", "Lowther", "Kirkby", "Brougham", "Shap", "Kendal", "Cartmel", "Brough"], "culture": "saxon"}, "Minsk": {"settlements": ["Kapyl", "Kletsk", "Minsk", "Berezino", "Maladzyechna", "Valozhyn", "Borisow", "Nesvizh"], "culture": "ilmenian"}, "Mstislavl": {"settlements": ["Chachersk", "Rahacou", "Chavusy", "Zhlobin", "Bychaw", "Mstitslavl", "Krychaw", "Mogilev"], "culture": "severian"}, "Turov": {"settlements": ["Petrykaw", "Mazyr", "Turov", "Dubrovitsya", "Bobruisk", "Yelsk", "Slutsk", "Zhytkavichy"], "culture": "volhynian"}, "Lyubech": {"settlements": ["Klimovo", "Loyew", "Lyubech", "Rechytsa", "Zlynka", "Novozybkov", "Brahin", "Gomel"], "culture": "severian"}, "Chernigov": {"settlements": ["Nizhyn", "Kozelets", "Borzna", "Gorodets", "Mglin", "Sosnytsia", "Chernigov", "Horodnia"], "culture": "severian"}, "Pereyaslavl": {"settlements": ["Hadyach", "Velykisorochyntsi", "Boryspil", "Chornukhy", "Lokhvytsia", "Pereyaslavl", "Hrebinka", "Myrhorod"], "culture": "severian"}, "Chortitza": {"settlements": ["Khorol", "Lubny", "Ltava", "Baszmacka", "Alexandrowsk", "Rasumowka", "Vosnesjensk"], "culture": "hungarian"}, "Lukomorie": {"settlements": ["Huliaipole", "Kushunum", "Kalchik", "Onkhiv", "Polohy", "Kalmius", "Chernihivka"], "culture": "khazar"}, "Lower Dniepr": {"settlements": ["Tokmak", "Kyzylyar", "Pryazovske", "Shagingirei", "Bilozerka", "Kuturogly", "Kairy"], "culture": "khazar"}, "Crimea": {"settlements": ["Kezlev", "Saq", "Qarasuvbazar", "Dzhankoy", "Aqmescit", "Qurman", "Perekop"], "culture": "khazar"}, "Durham": {"settlements": ["Auckland", "Chester-Le-Street", "Raby", "Gateshead", "Jarrow", "St Cuthbert", "Durham", "Hartlepool"], "culture": "saxon"}, "Cherson": {"settlements": ["Neapol", "Kerkinitis", "Kalamita", "Cembalo", "Charax", "Sevastoupolis", "Doros", "Kherson"], "culture": "greek"}, "Theodosia": {"settlements": ["Caulita", "Funan", "Olyva", "Lusta", "Kimmerikon", "Soldaia", "Caffa", "Theodosia"], "culture": "greek"}, "Korchev": {"settlements": ["Zavitne", "Vosporo", "Baherove", "Nymphaion", "Cherco", "Panticapea", "Chystopillia"], "culture": "greek"}, "Lower Don": {"settlements": ["Latonovo", "Vesely", "Ryasnoye", "Matveevkurgan", "Novoazovsk", "Marfinka", "Skorokhod"], "culture": "khazar"}, "Desht-I-Kipchak": {"settlements": ["Krasne", "Kramatorsk", "Lyman", "Mospyne", "Druzhkivka", "Dobropillia", "Sviatohirsk"], "culture": "khazar"}, "Sharukan": {"settlements": ["Khorysdan", "Sumy", "Challykala", "Izyum", "Kupyansk", "Balakliia", "Lyubotin"], "culture": "hungarian"}, "Sugrov": {"settlements": ["Khratayak", "Khursa", "Oboyan", "Tim", "Khazar", "Yauchy", "Fatezh"], "culture": "hungarian"}, "Novgorod Seversky": {"settlements": ["Starodub", "Glukhov", "Putivl", "Trubchevsk", "Semenivka", "Rysk", "Novgorodseversky", "Sevsk"], "culture": "severian"}, "Smolensk": {"settlements": ["Przhevalskoye", "Velizh", "Demidov", "Krasnoi", "Rodnya", "Yartsevo", "Smolensk"], "culture": "ilmenian"}, "Vyazma": {"settlements": ["Dorogobuzh", "Vyazma", "Gzhatsky", "Dukhov", "Ugra", "Vyazkholm", "Safonovo", "Yelnya"], "culture": "ilmenian"}, "York": {"settlements": ["York", "Skipton", "Conisbrough", "Pontefract", "Scarborough", "Richmond", "St Peters", "Hull"], "culture": "saxon"}, "Tver": {"settlements": ["Vyshnyvolochyok", "Zubtsov", "Bezhichi", "Tver", "Udomelski", "Torzhok", "Tvergorodok", "Ostashkov"], "culture": "ilmenian"}, "Uglich": {"settlements": ["Pertoma", "Kalyazin", "Tikhmenevo", "Kashin", "Myshkin", "Novynekouz", "Ustscheksna", "Uglich"], "culture": "mordvin"}, "Yaroslavl": {"settlements": ["Timerevo", "Putyatino", "Yaroslavl", "Semibratovo", "Karabikha", "Volgostroy", "Romanov", "Tolga"], "culture": "mordvin"}, "Pereyaslavl Zalessky": {"settlements": ["Pereyaslavlzalessky", "Sergiyevposad", "Karabanovo", "Kubrinsk", "Kupanskoye", "Aleksandrov", "Khmelniki", "Strunino"], "culture": "mordvin"}, "Rostov": {"settlements": ["Spasoyakovlevsky", "Karash", "Rostov", "Gavrilovyam", "Sarskoyegorodishche", "Shurskol", "Borisoglebsky", "Petrovskoye"], "culture": "mordvin"}, "Moskva": {"settlements": ["Serpukhov", "Belyov", "Kaluga", "Rzhev", "Klin", "Rogozhi", "Mozhaysk"], "culture": "mordvin"}, "Bryansk": {"settlements": ["Mtsensk", "Dyatkovo", "Belev", "Karachev", "Klynov", "Orel", "Bryansk"], "culture": "severian"}, "Pronsk": {"settlements": ["Tula", "Mikhaylov", "Bogoroditsk", "Yelets", "Ryazhsk", "Pronsk", "Skopin", "Sergijewskoje"], "culture": "mordvin"}, "Kolomna": {"settlements": ["Kolomna", "Zaraysk", "Ramenskoye", "Bronnitsy", "Peski", "Egorevsk", "Cherkizovo", "Glukhovichi"], "culture": "mordvin"}, "Mordva": {"settlements": ["Temnikow", "Yavas", "Ardatovo", "Krasnoslobodsk", "Yalga", "Insar", "Penza"], "culture": "mordvin"}, "Lancaster": {"settlements": ["Gisburn", "Salford", "Bolton", "Furness", "Lancaster", "Clitheroe", "Sawley", "Preston"], "culture": "saxon"}, "Ryazan": {"settlements": ["Klepiki", "Grodets", "Spassk", "Korablino", "Sasovo", "Solotcha", "Ryazan", "Rybnino"], "culture": "mordvin"}, "Murom": {"settlements": ["Mordovshchikovo", "Vyksa", "Moramar", "Murom", "Lipnya", "Melenki", "Vilya", "Kulebaki"], "culture": "mordvin"}, "Vladimir": {"settlements": ["Vladimir", "Petuschki", "Yuryevpolsky", "Sudogda", "Undol", "Volochok", "Sobinka", "Kosterevo"], "culture": "mordvin"}, "Suzdal": {"settlements": ["Suzstarodub", "Suzivanovo", "Kovrov", "Lezhnevo", "Suzdal", "Bogolyubovo", "Seredaupino", "Teykovo"], "culture": "mordvin"}, "Nizhny Novgorod": {"settlements": ["Balakhna", "Nizhnynovgorod", "Vasilyeva", "Sarov", "Knyaginino", "Kstovo", "Bor", "Bogorodsk"], "culture": "mordvin"}, "Gorodez": {"settlements": ["Pravdinsk", "Puchishche", "Kitezh", "Sokolskoye", "Feodorovsky", "Gorkovskoye", "Lukh", "Gorodez"], "culture": "mordvin"}, "Galich Mersky": {"settlements": ["Chistyebory", "Susanino", "Isaevo", "Galichmersky", "Buy", "Levkovo", "Gradmersky", "Kadyy"], "culture": "mordvin"}, "Mozhaysk": {"settlements": ["Volgamozhaysk", "Shakhunya", "Uren", "Kiknur", "Vakhtan", "Tonshaevo", "Yaransk", "Varnavino"], "culture": "mordvin"}, "Merya": {"settlements": ["Mariturek", "Morki", "Provoi", "Kilemary", "Lopatino", "Tsikma", "Volzhsk"], "culture": "mordvin"}, "Grassland Cheremisa": {"settlements": ["Cistay", "Aznaqay", "Zay", "Bua", "Bawli", "Alabuga"], "culture": "mordvin"}, "Chester": {"settlements": ["Sandbach", "Chester", "Nantwich", "Halton", "Malpas", "Northwich", "Macclesfield", "Beeston"], "culture": "saxon"}, "Chuvash": {"settlements": ["Sundyr", "Alatyr", "Yadrin", "Kozlovka", "Tsivilsk", "Makaryevo", "Cheboksary"], "culture": "mordvin"}, "Mountain Cheremisa": {"settlements": ["Kanadey", "Barysh", "Melekess", "Stanichnaya", "Vybornaya", "Butyrskaya", "Pokrovskoye"], "culture": "mordvin"}, "Burtasy": {"settlements": ["Sosnovyostrov", "Mechetnaya", "Balakova", "Pokrovsk", "Atkarsk", "Rtishchevo", "Golykaramysh"], "culture": "mordvin"}, "Khopyor": {"settlements": ["Ustmedveditskaya", "Uvarovo", "Kirsanov", "Uryupin", "Balashov", "Borisoglebsk"], "culture": "mordvin"}, "Sarkel": {"settlements": ["Semikarakorsk", "Kazarki", "Belayavezha", "Ustdonetskiy", "Nizhchir", "Kotelnikovo", "Tsimlyanskoye"], "culture": "khazar"}, "Don Portage": {"settlements": ["Ryumino", "Loq", "Donskoy", "Tary", "Illovlya", "Ozerki", "Illevka"], "culture": "khazar"}, "Tana": {"settlements": ["Cherkassk", "Ustaksayaskaya", "Bataysk", "Monastyrsky", "Sulin", "Gundorovka", "Rostovnadonu"], "culture": "khazar"}, "Azov": {"settlements": ["Kagalnik", "Sadki", "Azaq", "Eysk", "Kugey", "Akhtarsk", "Katon"], "culture": "khazar"}, "Tmutarakan": {"settlements": ["Mapa", "Bata", "Tumnev", "Jevlisia", "Sujukqale", "Tsemes"], "culture": "khazar"}, "Kuban": {"settlements": ["Podkumok", "Beshtau", "Kuban", "Psekups", "Coparia", "Kirpili"], "culture": "khazar"}, "Blekinge": {"settlements": ["Lyckeby", "Elleholm", "Avaskar", "Lister", "Solvesborg Slott", "Lycka", "Ronneby", "Solvesborg"], "culture": "norse"}, "Perfeddwlad": {"settlements": ["Llanelwy", "Denbigh", "Basingwerk", "Rhuddlan", "Flint", "Ruthin", "Ewloe", "Hawarden"], "culture": "welsh"}, "Abkhazia": {"settlements": ["Bzyb", "Pitsunda", "Zugdidi", "Anakopia", "Tskhoumi", "Abaatha", "Egrisi", "Gagra"], "culture": "georgian"}, "Imeretia": {"settlements": ["Geguti", "Kutaisi", "Bagrati", "Ghelati", "Tsikhegoji", "Lentekhi", "Motsameta", "Khoni"], "culture": "georgian"}, "Kasogs": {"settlements": ["Zikh", "Koshkhab", "Bakhtarakhtar", "Sarytyuz", "Samiran", "Ustdzeghuta", "Eltarkan"], "culture": "alan"}, "Alania": {"settlements": ["Magas", "Zaur", "Arkhyz", "Tkhabayerdy", "Tskhinval", "Tamarasheni", "Zadalesk"], "culture": "alan"}, "Kuma": {"settlements": ["Kuliyurt", "Arslanbek", "Tereklimekteb", "Dylym", "Gums", "Babayurt", "Kizilyurt"], "culture": "alan"}, "Manych": {"settlements": ["Kunay", "Nartkala", "Makhach", "Karabulak", "Terek", "Makhmudmekteb", "Malgobekbalka"], "culture": "alan"}, "Yegorlyk": {"settlements": ["Yamki", "Kuguty", "Madjar", "Stauropolis", "Beshpagir", "Kiankiz", "Erkenshakhar"], "culture": "alan"}, "Sarpa": {"settlements": ["Yashalta", "Ketchenery", "Ysaganaman", "Bachanta", "Karatchaplak", "Ikburul"], "culture": "khazar"}, "Lower Volga": {"settlements": ["Prishib", "Serebrjakovo", "Dubovka", "Tsaritsyn", "Kamyshin", "Petrovval", "Kotovo"], "culture": "khazar"}, "Syrt": {"settlements": ["Shungut", "Kinel", "Syzran", "Bandja", "Sarbay", "Osinki", "Tashia"], "culture": "bolghar"}, "Lincoln": {"settlements": ["Lincoln", "Bardney", "Spalding", "Grantham", "Louth", "Gainsborough", "Stamford", "Boston"], "culture": "saxon"}, "Bulgar": {"settlements": ["Tetyushi", "Arbuga", "Tawille", "Iq", "Suar", "Koshki", "Balimer"], "culture": "bolghar"}, "Qazan": {"settlements": ["Pakli", "Usttuntor", "Pal", "Uymuzh", "Krmayak", "Belyaevka"], "culture": "bolghar"}, "Votyaki": {"settlements": ["Bisert", "Ufimskiy", "Sarana", "Shamary", "Arti", "Shalya", "Atig"], "culture": "komi"}, "Bilyar": {"settlements": ["Urussu", "Bryakhimov", "Bogulma", "Cukataw", "Dzhalil", "Tukhchin", "Nurlat"], "culture": "bolghar"}, "Ashli": {"settlements": ["Janauyl", "Durtojle", "Blagovescen", "Yamantaw", "Boro", "Tuimasy", "Daulakan"], "culture": "bolghar"}, "Bashkirs": {"settlements": ["Chishmy", "Sterlitamak", "Meleus", "Belebey", "Beloret", "Isembaj", "Bajmaq"], "culture": "bolghar"}, "Pecheneg": {"settlements": ["Sadovy", "Saraktash", "Sakmara", "Kargala", "Khutorka", "Kichkas", "Tolkachi"], "culture": "bolghar"}, "Uzens": {"settlements": ["Ushkuduk", "Aytbay", "Kyzylasker", "Krykuru", "Khasan", "Kosoba", "Akkus"], "culture": "khazar"}, "Guryev": {"settlements": ["Birlik", "Besikty", "Yesmakan", "Sarayjuk", "Zhanakush", "Karabatyr", "Mantyube"], "culture": "turkish"}, "Saray": {"settlements": ["Chernyyar", "Pokrovka", "Tsaganaman", "Dzhelga", "Bataevka", "Uspenka", "Saray"], "culture": "khazar"}, "Leicester": {"settlements": ["Newark", "Hucknall", "Nottingham", "Southwell", "Leicester", "Newstead", "Tickhill", "Worksop"], "culture": "saxon"}, "Itil": {"settlements": ["Tumak", "Kharabali", "Alga", "Khaganbaligh", "Saqsin", "Kamyzyak"], "culture": "khazar"}, "Kangly": {"settlements": ["Makat", "Qulsary", "Akbulak", "Koshkar", "Bakachi", "Akkube", "Kizay"], "culture": "turkish"}, "Turkestan": {"settlements": ["Aralkum", "Kosskul", "Emba", "Saksaulskiy", "Akespe", "Sapak", "Akshelek"], "culture": "turkish"}, "Aral": {"settlements": ["Sokyrbulak", "Karakul", "Kuljandi", "Kaszkarata", "Aszczeatrik", "Dawletgirei", "Kosbulak"], "culture": "turkish"}, "Mangyshlak": {"settlements": ["Amankyzylit", "Ashchimuryn", "Sayutes", "Uzen", "Kzyluzen", "Araldy", "Tigen"], "culture": "turkish"}, "Usturt": {"settlements": ["Karamola", "Akkuduk", "Barsakelmos", "Bussaga", "Sumbe", "Sengirkum", "Aksu"], "culture": "turkish"}, "Khiva": {"settlements": ["Kath", "Darvaza", "Sumanay", "Kuskupir", "Khiva", "Tahta", "Kizketken", "Atajab"], "culture": "persian"}, "Kara-Kum": {"settlements": ["Yangadzha", "Kyzylsu", "Cheleken", "Dzhanga", "Ohk", "Awaza", "Bekdas", "Gazanjyk"], "culture": "persian"}, "Bukhara": {"settlements": ["Chardjul", "Karkuh", "Kogon", "Gizhduvan", "Vabkent", "Ayrybaba", "Agar", "Bukhara"], "culture": "sogdian"}, "Konjikala": {"settlements": ["Kyzylarvat", "Nisa", "Sarahs", "Farava", "Abiward", "Gokdepe", "Konjikala", "Ulugdepe"], "culture": "persian"}, "Derby": {"settlements": ["Bakewell", "Wirksworth", "Burton", "Derby", "Chesterfield", "Repton", "Bolsover", "Castleton"], "culture": "saxon"}, "Merv": {"settlements": ["Tagtabazar", "Yoloten", "Wekilbazar", "Bayramaly", "Gulanly", "Kushka", "Sakarcage", "Merv"], "culture": "persian"}, "Dihistan": {"settlements": ["Gasankuli", "Kumdag", "Torskhali", "Yarymtyk", "Akhur", "Bayatkhadzi", "Yasydepe", "Kemir"], "culture": "persian"}, "Tus": {"settlements": ["Bojnurd", "Mashhad", "Isfarayen", "Hasanabad", "Fagdatdezh", "Ghaisar", "Solak", "Shervan"], "culture": "persian"}, "Gurgan": {"settlements": ["Ramian", "Komishdepa", "Minudasht", "Gurgan", "Aqqala", "Khanbebin", "Kordkuy", "Gonbadeqabus"], "culture": "persian"}, "Nishapur": {"settlements": ["Shamat", "Daregaz", "Sabzevar", "Nishapur", "Chenaran", "Akhlamad", "Quchan", "Jajarm"], "culture": "persian"}, "Qohistan": {"settlements": ["Torbatjam", "Mahvalat", "Beyhaq", "Gonabad", "Fariman", "Torshiz", "Kalat", "Bardaskan"], "culture": "persian"}, "Lut": {"settlements": ["Aspak", "Kalateh", "Mazanabad", "Amanieh", "Tabas", "Esfandiar", "Dayhouk", "Bibaz"], "culture": "persian"}, "Sistan": {"settlements": ["Zabol", "Nok Kundi", "Haozdar", "Dehak", "Esfandak", "Dozz Aap", "Kuh Taftan", "Shahresukhteh"], "culture": "baloch"}, "Yazd": {"settlements": ["Taft", "Meybod", "Ardakan", "Zarch", "Chak Chak", "Nir", "Dar Anjir", "Yazd"], "culture": "persian"}, "Kerman": {"settlements": ["Bardsir", "Ghaleganj", "Kerman", "Nough", "Behdesir", "Maymand", "Zarand"], "culture": "persian"}, "Gwynedd": {"settlements": ["Degannwy", "Llanbadarn", "Conwy", "Cardigan", "Harlech", "Aberffraw", "Caernarfon", "Bangor Fawr"], "culture": "welsh"}, "Sirjan": {"settlements": ["Dehbid", "Borougheeyeh", "Abarkuh", "Mehrabad", "Sirjan", "Faragheh", "Shahrbabak"], "culture": "persian"}, "Hormuz": {"settlements": ["Kish", "Minab", "Gombroon", "Abarkawan", "Fin", "Bam", "Abu Musa", "Jiroth"], "culture": "persian"}, "Ladistan": {"settlements": ["Lad", "Forg", "Bandarkhamir", "Khonj", "Evaz", "Bastak", "Jask", "Morbagh"], "culture": "persian"}, "Fars": {"settlements": ["Khafr", "Lamerd", "Perozabad", "Gerash", "Kakhesasan", "Jahrom", "Estahbanat", "Darab"], "culture": "persian"}, "Shiraz": {"settlements": ["Shiraz", "Estakhr", "Abadeh", "Bishapur", "Persepolis", "Arsanjan", "Bavanat", "Azargarta"], "culture": "persian"}, "Hendjan": {"settlements": ["Behbahan", "Omidiyeh", "Argan", "Ramhormoz", "Susa", "Bandarshahpur", "Jayzan", "Bandaremashoor"], "culture": "persian"}, "Esfahan": {"settlements": ["Sedeh", "Khansar", "Esfahan", "Abyaneh", "Kashan", "Ardestan", "Qomsheh", "Zarrinshahr"], "culture": "persian"}, "Avhaz": {"settlements": ["Dezful", "Helen", "Farsan", "Shushtar", "Shahrekord", "Idhaj", "Koohrang", "Masjedsoleyman"], "culture": "persian"}, "Khozistan": {"settlements": ["Dora", "Ahvaz", "Abadan", "Shadegan", "Hoveizeh", "Fao", "Izaj", "Khorramshahr"], "culture": "persian"}, "Basra": {"settlements": ["Kalaatderat", "Qurna", "Basra", "Ummqasr", "Arah", "Mohammera", "Azzubayr", "Sukelsheyuhk"], "culture": "bedouin_arabic"}, "Powys": {"settlements": ["Llandinam", "Montgomery", "Radnor", "Rhayader", "Llangollen", "Caersws", "Mathrafal", "Glascwm"], "culture": "welsh"}, "Kuwait": {"settlements": ["Anthemusias", "Ashshuaybah", "Falalheel", "Alwafra", "Kuwait", "Arrawdatayn", "Ikaros", "Khinan"], "culture": "bedouin_arabic"}, "Damman": {"settlements": ["Avan", "Najmah", "Abuhadriya", "Hinnah", "Qatif", "Jubail", "Alaba"], "culture": "bedouin_arabic"}, "Al Hasa": {"settlements": ["Mubarraz", "Foda", "Omran", "Oyoon", "Ghunan", "Khobar", "Holuf", "Abqaiq", "Alhasa"], "culture": "bedouin_arabic"}, "Bahrein": {"settlements": ["Al Masqar", "Umm As Sabaan", "Sitra", "Murwab", "Batn Ardasir", "Jidda", "Hamala", "Aldur"], "culture": "bedouin_arabic"}, "Rummah": {"settlements": ["Hafaralbatin", "Samoudah", "Altheebiyah", "Arraqai", "Assuayerah", "Assufayri", "Qaisumah", "Alqalt"], "culture": "bedouin_arabic"}, "Kufa": {"settlements": ["Shuyukh", "Chibayish", "Hammar", "Ragai", "Suqash", "Kufa", "Qurnah", "Bussayyah"], "culture": "bedouin_arabic"}, "Tigris": {"settlements": ["Warka", "Qalatsjergat", "Ishan", "Nuffar", "Tellelhiba", "Majaralkabir", "Bismaya", "Samawah"], "culture": "kurdish"}, "Luristan": {"settlements": ["Koohdasht", "Poledokhtar", "Dezbar", "Khorramabad", "Dorood", "Borujerd", "Aligoodarz", "Alashtar"], "culture": "persian"}, "Hamadan": {"settlements": ["Ganjnameh", "Kabudrahang", "Ecbatana", "Asadabad", "Roudavar", "Nahavand", "Hamadan", "Malayer"], "culture": "persian"}, "Qom": {"settlements": ["Jafariyeh", "Salafchegan", "Dastjerd", "Qanavat", "Kahak", "Qom", "Jamkaran", "Khourabad"], "culture": "persian"}, "Shrewsbury": {"settlements": ["Clun", "Ludlow", "Chirk", "Oswestry", "Bridgnorth", "Wenlock", "Whitchurch", "Shrewsbury"], "culture": "welsh"}, "Qwivir": {"settlements": ["Damqan", "Semnan", "Sharequmis", "Gerdkuh", "Darvar", "Kohandej", "Dehnamak", "Sangsar"], "culture": "persian"}, "Tabaristan": {"settlements": ["Sari", "Farim", "Lavij", "Firuzkuh", "Rarem", "Mamatir", "Chamnoo", "Amul"], "culture": "persian"}, "Alamut": {"settlements": ["Rostamrood", "Alamut", "Garmsar", "Varamin", "Chaloos", "Kalar", "Damavand", "Sisangan", "Kojoor"], "culture": "persian"}, "Rayy": {"settlements": ["Hashtgerd", "Shahriar", "Eslamshahr", "Tehran", "Pakdasht", "Rayy", "Karaj"], "culture": "persian"}, "Qazwin": {"settlements": ["Qazwin", "Buinzahra", "Takestan", "Alvand", "Avaj", "Ahmadabad", "Lambsar", "Abeyek"], "culture": "persian"}, "Daylam": {"settlements": ["Khunaj", "Alamut", "Mahneshan", "Soltaniyeh", "Gheydar", "Tarom", "Zanjan"], "culture": "persian"}, "Gilan": {"settlements": ["Talysh", "Rudbar", "Masouleh", "Rudkhan", "Astara", "Gilan", "Lahijan"], "culture": "persian"}, "Tabriz": {"settlements": ["Sarab", "Shabestar", "Babak", "Ahar", "Tabriz", "Dihnakhirjan", "Zahhak"], "culture": "kurdish"}, "Shirvan": {"settlements": ["Baku", "Absheron", "Salyan", "Altiagay", "Shirvan", "Khizirzinda", "Lankaran"], "culture": "persian"}, "Shemakha": {"settlements": ["Khachmaz", "Ahemakha", "Anig", "Shikhlar", "Maraza", "Khil", "Quba", "Chiraggala"], "culture": "persian"}, "Warwick": {"settlements": ["Dudley", "Tamworth", "Stafford", "Kenilworth", "Coventry", "Tutbury", "Lichfield", "Warwick"], "culture": "saxon"}, "Azerbaijan": {"settlements": ["Kapalak", "Kalaberd", "Urmiah", "Takhtesuleiman", "Bastam", "Deglane", "Chaldoran"], "culture": "armenian"}, "Suenik": {"settlements": ["Gandzassar", "Prochabert", "Goris", "Ghapan", "Areni", "Tatev", "Vorotnavank", "Noravank"], "culture": "armenian"}, "Dwin": {"settlements": ["Khorvirap", "Erebuni", "Alaverdi", "Etchmiadzin", "Matsnaberd", "Sanahin", "Dvin"], "culture": "armenian"}, "Albania": {"settlements": ["Shaki", "Chukhurkabala", "Gelersengorersen", "Kabala", "Barda", "Ganja", "Darussoltan", "Emli"], "culture": "armenian"}, "Derbent": {"settlements": ["Narinkala", "Juma", "Kuli", "Humraj", "Tayus", "Chikkulkan", "Derbent", "Datuna"], "culture": "armenian"}, "Semender": {"settlements": ["Burgaikala", "Tarki", "Urtseki", "Khannalkala", "Balanjar", "Semender", "Khattibaku", "Kumukh"], "culture": "alan"}, "Kakheti": {"settlements": ["Telavi", "Bochorma", "Zedazaden", "Bodbe", "Gremi", "Dzveligalavani", "Davidgareja", "Sighnaghi"], "culture": "georgian"}, "Guria": {"settlements": ["Khula", "Bukistsikhe", "Ozurgeti", "Udabno", "Tsikhisdziri", "Skhalta", "Batum", "Gonio"], "culture": "georgian"}, "Trapezous": {"settlements": ["Rizaion", "Alucra", "Paiperta", "Rizini", "Koralla", "Dereli", "Kelkit", "Trapezous"], "culture": "greek"}, "Kartli": {"settlements": ["Mtskheta", "Narikala", "Bebristsikhe", "Tbilisi", "Svetitskhoveli", "Djvari", "Sioni"], "culture": "georgian"}, "Northampton": {"settlements": ["Ramsey", "Crowland", "Kettering", "Cambridge", "Rockingham", "Huntingdon", "Peterborough", "Northampton"], "culture": "saxon"}, "Tao": {"settlements": ["Khakhuli", "Vardzia", "Oshki", "Akhaltsikhe", "Khertvisi", "Ughtik", "Panaskerti", "Artanuji"], "culture": "georgian"}, "Ani": {"settlements": ["Karuts", "Artashat", "Surpasdvadzadzin", "Midjnaberd", "Oshakan", "Ani", "Zvartnots", "Karutsberd"], "culture": "armenian"}, "Vaspurakan": {"settlements": ["Hadamakert", "Van", "Aghtamar", "Varagavank", "Vostan", "Bakear", "Surbkhach", "Haykaberd"], "culture": "armenian"}, "Amida": {"settlements": ["Amida", "Ulucamii", "Mayyafarikin", "Suraamede", "Egil", "Kiaburc", "Hazretisuleymancamii", "Idtodyolataloho"], "culture": "kurdish"}, "Nisibin": {"settlements": ["Nusaybin", "Sittiradviyyemadrasa", "Kerburan", "Dayrodmorgabriel", "Savur", "Cizre", "Yaqobnsibnaya", "Dairodmorhannanyo"], "culture": "kurdish"}, "Oromieh": {"settlements": ["Takhtesoleyman", "Khoy", "Chaldiran", "Charekelisa", "Avajiq", "Mahabad", "Oroumieh", "Salmas"], "culture": "kurdish"}, "Kurdistan": {"settlements": ["Dawodiya", "Dehi", "Duhok", "Marqayoma", "Bebadi", "Harmashi", "Sarsink", "Araden"], "culture": "kurdish"}, "Kirkuk": {"settlements": ["Kifri", "Daquq", "Halabja", "Chuartan", "Makhmur", "Dukan", "Kirkuk", "Ranya"], "culture": "kurdish"}, "Kermanshah": {"settlements": ["Kangavar", "Kuzaran", "Hulwan", "Paveh", "Javanroud", "Mahalkufa", "Kermanshah", "Ravansar"], "culture": "kurdish"}, "Ilam": {"settlements": ["Abdanan", "Ghalehghiran", "Chahartaghi", "Mehran", "Towhid", "Ilam", "Hezardar", "Dehloran"], "culture": "kurdish"}, "Bedford": {"settlements": ["Luton", "Bedford", "Hertford", "Berkhamsted", "Ashridge", "Dunstable", "Watford", "St Albans"], "culture": "saxon"}, "Al Amarah": {"settlements": ["Suwaira", "Amarah", "Hai", "Badra", "Zurbatiyah", "Kutelamara", "Wasit", "Azeeziaya"], "culture": "levantine_arabic"}, "Al Nasiryah": {"settlements": ["Nasiryah", "Muntafiq", "Dhiqar", "Qalatsukkar", "Shahrain", "Telloh", "Shatra", "Mukayyar"], "culture": "levantine_arabic"}, "Istakhr": {"settlements": ["Kamin", "Iqlid", "Abarquh", "Abadha", "Istakhr", "Main", "Sarmaq"], "culture": "persian"}, "Al Nadjaf": {"settlements": ["Jasim", "Jaarah", "Nadjaf", "Midhrawi", "Rahbah", "Kufah", "Taqtaqanah", "Rashid"], "culture": "levantine_arabic"}, "Baghdad": {"settlements": ["Baqubah", "Latifiya", "Babel", "Madain", "Iskandariya", "Hillah", "Taji"], "culture": "levantine_arabic"}, "Karbala": {"settlements": ["Ofak", "Hindiya", "Ukhaidir", "Hamzah", "Ainaltamur", "Qisair", "Shamiyah", "Karbala"], "culture": "levantine_arabic"}, "Deir": {"settlements": ["Hit", "Rutbah", "Kasra", "Anbar", "Takrit", "Ramadi", "Rawa", "Nehardea"], "culture": "assyrian"}, "Euphrates": {"settlements": ["Tagrit", "Amirli", "Faris", "Samarra", "Dujail", "Balad", "Ishaqi", "Bayji"], "culture": "assyrian"}, "Mosul": {"settlements": ["Aqrah", "Bartella", "Bakhdida", "Baqofah", "Mosul", "Arbil", "Shekhan"], "culture": "assyrian"}, "Al Jazira": {"settlements": ["Hamoukar", "Dayrik", "Amuda", "Dakhiliyah", "Darbasiyah", "Hasakah", "Qamishhlo", "Teltamer"], "culture": "levantine_arabic"}, "Edessa": {"settlements": ["Sruk", "Kaisun", "Edesurfa", "Samsat", "Bile", "Tulupe", "Harran", "Edessa"], "culture": "armenian"}, "Oriel": {"settlements": ["Clones", "Clogher", "Drogheda", "Armagh", "Monaghan", "Olouth", "Dundalk", "Ardee"], "culture": "irish"}, "Norfolk": {"settlements": ["Chatteris", "Norwich", "Thetford", "Lynn", "Yarmouth", "Elmham", "Buckenham", "Castle Rising"], "culture": "saxon"}, "Bira": {"settlements": ["Bira", "Resaina", "Samrah", "Derik", "Qoser", "Stewr", "Tella", "Qalarebete"], "culture": "kurdish"}, "Taron": {"settlements": ["Arakelots", "Mush", "Akhlat", "Sason", "Manzikert", "Glak", "Artchesh", "Ararati"], "culture": "armenian"}, "Mesopotamia": {"settlements": ["Martyropolis", "Tzimisca", "Tigranakert", "Mayafaraqin", "Jermuk", "Arghana", "Lice", "Hani"], "culture": "armenian"}, "Karin": {"settlements": ["Kirklarkilisesi", "Karin", "Daroynk", "Owshank", "Baghesh", "Pasen", "Tercan"], "culture": "armenian"}, "Theodosiopolis": {"settlements": ["Satala", "Thera", "Askale", "Argyropolis", "Oukhiti", "Tortum", "Theodosiopolis", "Citharizum"], "culture": "armenian"}, "Chaldea": {"settlements": ["Tilgarimo", "Heracleopolis", "Cotyora", "Sebastea", "Ibora", "Podandos", "Camachus", "Kerasous"], "culture": "greek"}, "Koloneia": {"settlements": ["Gerjanis", "Mazaka", "Gamakh", "Tephrice", "Akn", "Anatolnikopolis", "Celtzene", "Koloneia"], "culture": "armenian"}, "Melitene": {"settlements": ["Samosata", "Kigi", "Arguvan", "Arca", "Seneqerim", "Melitene", "Corduene", "Yedisu"], "culture": "armenian"}, "Tell Bashir": {"settlements": ["Turbessel", "Manbij", "Zeugma", "Birtha", "Jarabulus", "Makedonopolis", "Buzaa", "Nizip"], "culture": "levantine_arabic"}, "Asas": {"settlements": ["Tabqa", "Zaazouaa", "Asas", "Kallinikos", "Resafa", "Rakka", "Talabyad", "Souriya"], "culture": "levantine_arabic"}, "Suffolk": {"settlements": ["Dunwich", "Bury", "Bungay", "Framlingham", "Ely", "Stow", "Ipswich", "Lowestoft"], "culture": "saxon"}, "Al Bichri": {"settlements": ["Sirhi", "Deiralzur", "Shamiyya", "Mayadin", "Mhaymidah", "Osrhoene", "Bichri", "Abu Kamal"], "culture": "levantine_arabic"}, "Sinjar": {"settlements": ["Hatra", "Telassar", "Baaj", "Kouyunik", "Nineveh", "Talkayf", "Nabiyunus", "Sinjar"], "culture": "assyrian"}, "Rahbah": {"settlements": ["Taraba", "Qummoualad", "Tlilin", "Anah", "Rahbah", "Nimreh", "Busan", "Salah"], "culture": "assyrian"}, "Druz": {"settlements": ["Salkhard", "Awas", "Shannireh", "Samj", "Thoula", "Dibin", "Ghariyah", "Busra"], "culture": "levantine_arabic"}, "Az Zarqa": {"settlements": ["Hashemiyya", "Khurqah", "Qasr Amra", "Russeifa", "Amratamad", "Zarqa", "Shabib", "Qasr Al Hallabat"], "culture": "levantine_arabic"}, "Al Habbariyah": {"settlements": ["Shabakah", "Nuayj", "Qutaysh", "Alhabbariyah", "Daydab", "Nukhaib", "Aljirami", "Adhaman"], "culture": "levantine_arabic"}, "Zanjan Abhar": {"settlements": ["Aba", "Wasamkuh", "Zahanj", "Abhar"], "culture": "persian"}, "Ar Ar": {"settlements": ["Ammaryah", "Umm Kunsur", "Ruthiyah", "Judaidah", "Shaka", "Dumat Al Jundal", "Uwayquilah", "Qasa"], "culture": "levantine_arabic"}, "Jeddah": {"settlements": ["Khulays", "Jeddah", "As Sirrayn"], "culture": "bedouin_arabic"}, "Al Jawf": {"settlements": ["Sakakah", "Tuwayr", "Radifah", "Al Jawf", "Qurayyat", "Dumat Al Jandal", "Aladan", "Tyer"], "culture": "levantine_arabic"}, "Medina": {"settlements": ["Farsh", "Medina", "Batn Nakhl", "Al Usayla", "Sidi Hamzah", "Milha", "Kuba"], "culture": "bedouin_arabic"}, "Mecca": {"settlements": ["Jmumum", "Qunfudhah", "Al Lith", "Qarn", "Taif", "Mecca", "Al Johfa", "Turubah"], "culture": "bedouin_arabic"}, "Essex": {"settlements": ["Havering", "Colchester", "Hedingham", "Dunmow", "Maldon", "Waltham", "Barking", "Pleshey"], "culture": "saxon"}, "Hijaz": {"settlements": ["Al Ola", "Tayma", "Madain Salih", "Higra", "Tawala", "Samur", "Mughayra", "Leuke Kome"], "culture": "levantine_arabic"}, "Tabuk": {"settlements": ["Tabuk", "Muwaylih", "Abu Ujayyijat", "Shaghab", "Gabouk", "Mariyiat", "Sharmah", "Duba"], "culture": "levantine_arabic"}, "Al Aqabah": {"settlements": ["Quwairah", "Reeshah", "Elifaz", "Yotvata", "Aqabah", "Samar", "Feifa", "Mazraa"], "culture": "levantine_arabic"}, "Petra": {"settlements": ["Tophel", "Shoubak", "Hamza", "Husseiniya", "Bozrah", "Petra", "Abdelliya", "Wadi Musa"], "culture": "levantine_arabic"}, "Madaba": {"settlements": ["Wadi Al Sir", "Madaba", "Sahab", "Bilal", "Muwaqqar", "Samhal", "Qastal", "Umm Ar-Rasas"], "culture": "levantine_arabic"}, "Amman": {"settlements": ["Fuheis", "Jerash", "Dhiban", "Deir Alla", "Amman", "Al Balqa", "Salt", "Mahis"], "culture": "levantine_arabic"}, "Irbid": {"settlements": ["Ummqais", "Gadera", "Aydoun", "Aljun", "Habisjaldak", "Irbid", "Yarmouk", "Pella"], "culture": "levantine_arabic"}, "Al Mafraq": {"settlements": ["Thughra", "Jarash", "Elemtaih", "Taebah", "Ramtah", "Mafraq", "Nasib", "Buwayda"], "culture": "levantine_arabic"}, "Syria": {"settlements": ["Adra", "Buraq - Castle", "Jarba", "Hayjanah", "Otaybah", "Amrah", "Qasmiye", "Baly"], "culture": "levantine_arabic"}, "Damascus": {"settlements": ["Qsarbardawil", "Izra", "Alsanamayn", "Suada", "Daraa", "Duma", "Shahba", "Damascus"], "culture": "levantine_arabic"}, "Tadmor": {"settlements": ["Subaykhan", "Assusah", "Husaiba", "Bukamal", "Asharah", "Alqunjah", "Alqaim", "Salhiyah"], "culture": "levantine_arabic"}, "Kent": {"settlements": ["Lympne", "Faversham", "Sandwich", "Tonbridge", "Canterbury", "Dover", "Rochester", "Romney"], "culture": "saxon"}, "Palmyra": {"settlements": ["Arraml", "Palmyra", "Arak", "Khirbat", "Alqasr", "Jihar", "Alhuwaysis"], "culture": "levantine_arabic"}, "Homs": {"settlements": ["Qatna", "Sadad", "Alkhazandar", "Qadesh", "Homs", "Zweitina", "Marmarita", "Emesa"], "culture": "levantine_arabic"}, "Hama": {"settlements": ["Hama", "Qarqar", "Hamath", "Serjilla", "Kharsan", "Mhardeh", "Salamiyah"], "culture": "levantine_arabic"}, "Aleppo": {"settlements": ["Aleppo", "Sarmin", "Harim", "Qusayr", "Azaz", "Maaratannuman", "Lerminet"], "culture": "levantine_arabic"}, "Aintab": {"settlements": ["Amanus", "Aintab", "Hromgla", "Duluk", "Raban", "Marash", "Kyrrhos", "Ravendan"], "culture": "armenian"}, "Teluch": {"settlements": ["Hajin", "Koksen", "Komanal", "Kapan", "Tavplur", "Perre", "Teluch", "Germanias"], "culture": "greek"}, "Lykandos": {"settlements": ["Tzamandos", "Germanikeia", "Lykandos", "Cocussus", "Comanagene", "Papurius", "Arabissus", "Symposion"], "culture": "greek"}, "Kaisereia": {"settlements": ["Masaka", "Misti", "Dobada", "Zoropassos", "Sariz", "Venessa", "Talas", "Kaisereia"], "culture": "greek"}, "Amisos": {"settlements": ["Dazimon", "Neokaisarea", "Zela", "Thermodon", "Amasia", "Amisos", "Phadisane"], "culture": "greek"}, "Sinope": {"settlements": ["Germanicopolis", "Pompeiopolis", "Aboniteichos", "Sinope", "Amastris", "Talaura", "Comana", "Themiscyra"], "culture": "greek"}, "Guines": {"settlements": ["Calais", "Dunkerque", "Bourbourg", "Saintomer", "Gravelines", "Marck", "Guines", "Coulogne"], "culture": "old_frankish"}, "Herakleia": {"settlements": ["Polis", "Flaviopolis", "Claudiopolis", "Amastrine", "Bithynium", "Tium", "Herakleia", "Zephyropoli"], "culture": "greek"}, "Nikomedeia": {"settlements": ["Chalkedon", "Nikomedeia", "Praenetos", "Palodes", "Calpe", "Adapazari", "Malagina"], "culture": "greek"}, "Prusa": {"settlements": ["Docimium", "Adrastea", "Darieium", "Thyatira", "Miletopolis", "Pelopia", "Prusa", "Apamea"], "culture": "greek"}, "Kyzikos": {"settlements": ["Militopolis", "Artake", "Myrina", "Arisbe", "Percote", "Kremasti", "Kyzikos", "Adrianutherai"], "culture": "greek"}, "Abydos": {"settlements": ["Allianoi", "Elaia", "Pigai", "Alexandriatroas", "Aegae", "Cebrene", "Abydos"], "culture": "greek"}, "Smyrna": {"settlements": ["Phokaia", "Klazomeanai", "Smyrna", "Pergamon", "Chio", "Kydonia", "Erythrai", "Adramyttion"], "culture": "greek"}, "Ephesos": {"settlements": ["Palation", "Iassos", "Ephesos", "Tralles", "Magnesia", "Petron", "Miletos"], "culture": "greek"}, "Lykia": {"settlements": ["Limyra", "Mylasa", "Halikarnassos", "Phaselis", "Telmissos", "Kibyra", "Patara", "Myra"], "culture": "greek"}, "Laodikeia": {"settlements": ["Gordes", "Laodikeia", "Philadelphia", "Hieropolis", "Kona", "Rhoas", "Sardes", "Flaviupolis"], "culture": "greek"}, "Dorylaion": {"settlements": ["Polybotos", "Iustinianopolis", "Germia", "Kotiaion", "Orkistos", "Dorylaion", "Carura", "Pessinus"], "culture": "greek"}, "Boulogne": {"settlements": ["Ardres", "Fauquembergues", "Boulogne", "Saintpol", "Therouanne", "Ternouis", "Montreuil", "Hesdin"], "culture": "old_frankish"}, "Nikaea": {"settlements": ["Modrene", "Kotyaion", "Petobriga", "Optimatum", "Palaeokastron", "Yalova", "Nikaea", "Kios"], "culture": "greek"}, "Paphlagonia": {"settlements": ["Safranbolu", "Leontopolis", "Kastamonu", "Zaliscus", "Anastasiopolis", "Cabira", "Gangra", "Bolu"], "culture": "greek"}, "Galatia": {"settlements": ["Nyssa", "Kochisar", "Asponia", "Garsaura", "Karacaviran", "Mikissos", "Tavia", "Carissa"], "culture": "greek"}, "Ankyra": {"settlements": ["Germa", "Amorion", "Ankyra", "Gordoservon", "Haymana", "Nakoleia", "Akroynon", "Gordium"], "culture": "greek"}, "Sozopolis": {"settlements": ["Aezani", "Souzopolis", "Synnada", "Cadi", "Dinar", "Polidorion", "Isparta", "Kelainai"], "culture": "greek"}, "Attaleia": {"settlements": ["Sagalassos", "Side", "Slege", "Cibyra", "Panemotichus", "Sillyon", "Galanauros", "Attaleia"], "culture": "greek"}, "Limisol": {"settlements": ["Khirokitia", "Agridi", "Limmassol", "Dieudamour", "Morphou", "Kolossi", "Arsinoe", "Paphos"], "culture": "greek"}, "Famagusta": {"settlements": ["Famagusta", "Buffavento", "Nikosia", "Cithium", "Kyrenia", "Kantara", "Peristerona", "Sthilarion"], "culture": "greek"}, "Seleukeia": {"settlements": ["Ninica", "Germanak", "Selinus", "Irenopolis", "Anemurium", "Dalisandus", "Seleukeia", "Corycus"], "culture": "greek"}, "Ikonion": {"settlements": ["Terpe", "Gaspadale", "Ikonion", "Lisdra", "Isauria", "Laranda", "Sauatra", "Amblada"], "culture": "greek"}, "Yperen": {"settlements": ["Ypres", "Cassel", "Rosebeke", "Menen", "Roeselare", "Wervik", "Diksmuide", "Poperinge"], "culture": "old_frankish"}, "Tyana": {"settlements": ["Tyana", "Nazianus", "Archelais", "Tomarza", "Anatoliaheraklea", "Gamar", "Faustinopolis", "Cybistra"], "culture": "greek"}, "Tarsos": {"settlements": ["Pendosis", "Korikos", "Lamas", "Castabala", "Lampron", "Tarsos", "Zephyrium", "Bardzerben"], "culture": "greek"}, "Adana": {"settlements": ["Trazak", "Lajazzo", "Mopsuestia", "Mamistra", "Sis", "Vahka", "Adana", "Anazarba"], "culture": "greek"}, "Alexandretta": {"settlements": ["Myriandros", "Rhosus", "Portella", "Portbonnel", "Sarvantikar", "Alexandretta", "Derbasak", "Larochederissole"], "culture": "greek"}, "Antiocheia": {"settlements": ["Saone", "Harenc", "Antiocheia", "Baghras", "Hazart", "Darbsak", "Stsymeon", "Latakiah"], "culture": "greek"}, "Archa": {"settlements": ["Masyaf", "Kafroun", "Shayzar", "Chastelblanc", "Archa", "Treiz", "Famia"], "culture": "levantine_arabic"}, "Tortosa": {"settlements": ["Maraclea", "Jabala", "Valania", "Balemia", "Ruad", "Margat", "Alkhawabi", "Tortosa"], "culture": "levantine_arabic"}, "Tripoli": {"settlements": ["Alqulayat", "Alqadmus", "Nephin", "Boutron", "Syrtripoli", "Besmedin", "Arqah", "Gibelet"], "culture": "levantine_arabic"}, "Baalbek": {"settlements": ["Akkar", "Buissera", "Krakdeschevaliers", "Baalbek", "Chlifa", "Laboue", "Riyaq", "Zahle", "Halbah"], "culture": "levantine_arabic"}, "Safed": {"settlements": ["Subeiba", "Banyas", "Safed", "Karmel", "Chastelet", "Belvoir", "Qatsrin", "Toron"], "culture": "levantine_arabic"}, "Artois": {"settlements": ["Beaumetz", "Bouvines", "Bethune", "Arras", "Bapaume", "Lille", "Lens", "Terwaan"], "culture": "old_frankish"}, "Beirut": {"settlements": ["Beirut", "Sarepta", "Cavedetyron", "Sidon", "Journie", "Abualhasan", "Beitkfeya"], "culture": "levantine_arabic"}, "Tyrus": {"settlements": ["Casalimbert", "Megedel", "Scandalon", "Syrbelfort", "Sarafand", "Hunin", "Syrmontfort", "Tyrus"], "culture": "levantine_arabic"}, "Acre": {"settlements": ["Adelon", "Recordana", "Athlith", "Haifa", "Acre", "Syrcaesarea", "Merle", "Manawat"], "culture": "levantine_arabic"}, "Tiberias": {"settlements": ["Lafeve", "Bethsan", "Hattin", "Ashtera", "Tiberias", "Nazareth", "Caymont"], "culture": "levantine_arabic"}, "Jerusalem": {"settlements": ["Beitnuba", "Nablus", "Mirabel", "Saintsamuel", "Jerusalem", "Rammala", "Jericho"], "culture": "levantine_arabic"}, "Jaffa": {"settlements": ["Ramleh", "Lydda", "Yazur", "Beitdejan", "Qula", "Jaffa", "Arsuf", "Ibelin"], "culture": "levantine_arabic"}, "Hebron": {"settlements": ["Bethlehem", "Hebron", "Deimachar", "Bethgibelin", "Latrun", "Alsamoa", "Syrbelmont", "Saintcharlton"], "culture": "levantine_arabic"}, "Kerak": {"settlements": ["Punon", "Kirhaseset", "Zoar", "Krakdemoab", "Bozra", "Zaimona", "Tamar", "Kerak"], "culture": "levantine_arabic"}, "Monreal": {"settlements": ["Monreal", "Hurmniz", "Paran", "Idan", "Sela", "Tafila", "Bildad"], "culture": "levantine_arabic"}, "Beersheb": {"settlements": ["Rahat", "Estemon", "Gilat", "Ofakim", "Debir", "Beersheb", "Massada", "Abuzqayqa"], "culture": "levantine_arabic"}, "Brugge": {"settlements": ["Male", "Oostende", "Nieuwpoort", "Torhout", "Brugge", "Damme", "Aardenburg", "Sluys"], "culture": "old_frankish"}, "Ascalon": {"settlements": ["Ascalon", "Semsem", "Agelen", "Huidre", "Blanchegarde", "Laforbie", "Harbijah", "Bothme"], "culture": "levantine_arabic"}, "Darum": {"settlements": ["Gaza", "Abasan", "Darum", "Radwan", "Gerar", "Salqah", "Rafah", "Jarara"], "culture": "levantine_arabic"}, "Negev": {"settlements": ["Avdat", "Haluza", "Negev", "Dimona", "Albaqar", "Ezuz", "Kmehin", "Yeruham"], "culture": "levantine_arabic"}, "Maan": {"settlements": ["Buseira", "Maanalhasa", "Mutah", "Afra", "Shubak", "Bubeita", "Maan", "Maanaljafr"], "culture": "levantine_arabic"}, "Shahrazur": {"settlements": ["Shahrazur", "Sanda"], "culture": "kurdish"}, "Sinai": {"settlements": ["Sinbarqa", "Jabalsamra", "Mamlah", "Nabq", "Sharmelsheikh", "Dahab", "Attur", "Nuweiba"], "culture": "levantine_arabic"}, "Eilat": {"settlements": ["Eliot", "Yahel", "Tzofar", "Ketura", "Sapir", "Lotan", "Eilat", "Urim"], "culture": "levantine_arabic"}, "El-Arish": {"settlements": ["Kharruba", "Abuaweigila", "Birelhamma", "Zuwayid", "Arish", "Masyada", "Tukkot", "Mitmatna"], "culture": "levantine_arabic"}, "Farama": {"settlements": ["Mustabiq", "Seyan", "Romani", "Sin", "Farama", "Zaaraniq", "Birqatia", "Birelabd"], "culture": "levantine_arabic"}, "Pelusia": {"settlements": ["Pithom", "Said", "Alsalihiyah", "Tinis", "Ismaillia", "Serapeum", "Pelusia", "Sile"], "culture": "egyptian_arabic"}, "Zeeland": {"settlements": ["Zierikzee", "Cadzand", "Middelburg", "Borsele", "Veere", "Renesse", "Vlissingen"], "culture": "frisian"}, "Sarqihya": {"settlements": ["Clysma", "Suez", "Shallufa", "Alhaifar", "Atfih", "Agruda", "Sarqinya", "Taufiq"], "culture": "egyptian_arabic"}, "Quena": {"settlements": ["Qift", "Qus", "Abughusun", "Ummrus", "Quena", "Safaga", "Kosseir"], "culture": "egyptian_arabic"}, "Nubia": {"settlements": ["Anag", "Salala", "Tahtani", "Nafab", "Komotit", "Fanoidig", "Eirayab"], "culture": "nubian"}, "Makuria": {"settlements": ["Dongola", "Kawa", "Gabriya", "Qubban", "Kerma", "Kerat", "Affat"], "culture": "nubian"}, "Aswan": {"settlements": ["Aswan", "Philae", "Edfu", "Shellal", "Elefantina", "Veset", "Kalabsha", "Bigeh"], "culture": "egyptian_arabic"}, "Asyut": {"settlements": ["Asyut", "Egypabydos", "Meir", "Luxor", "Beitkhallaf", "Durunka", "Egypthebes", "Kusai", "Wannina"], "culture": "egyptian_arabic"}, "Cairo": {"settlements": ["Maadi", "Fustat", "Cairo", "Tekkekyahudiyya", "Memphis", "Helwan", "Heliopolis", "Merimdabenisalama"], "culture": "egyptian_arabic"}, "Manupura": {"settlements": ["Bubastis", "Qantir", "Manusura", "Bilbays", "Zagazig", "Almahallah", "Busiris", "Athribis"], "culture": "egyptian_arabic"}, "Delta": {"settlements": ["Burah", "Baramun", "Tanis", "Saramsah", "Burlus", "Fareskur", "Shirbin", "Damietta"], "culture": "egyptian_arabic"}, "Gabiyaha": {"settlements": ["Buto", "Disuq", "Mutubis", "Xois", "Sais", "Hermopolis", "Rosetta", "Fuwa"], "culture": "egyptian_arabic"}, "Breifne": {"settlements": ["Cavan", "Kilmore", "Longford", "Ardagh", "Dromahair", "Leitrim", "Drumcliffe", "Kells"], "culture": "irish"}, "Holland": {"settlements": ["Vlaardingen", "Haarlem", "Leiden", "Gouda", "Dordrecht", "Muiden", "Amsterdam", "Sgravenhage"], "culture": "frisian"}, "Gizeh": {"settlements": ["Zawyetalayran", "Abusir", "Ellisht", "Dashur", "Gizeh", "Aburowash", "Abughorob", "Saqqara"], "culture": "egyptian_arabic"}, "Buhairya": {"settlements": ["Elkharga", "Qasrfarfra", "Baris", "Budhkula", "Mut", "Abuminqar", "Buhairya", "Ismant"], "culture": "nubian"}, "Alexandria": {"settlements": ["Burgelarab", "Hammam", "Marabout", "Abukir", "Alexandria", "Elkanoun", "Naucratis", "Damanhur"], "culture": "egyptian_arabic"}, "Quattara": {"settlements": ["Alamelshwawish", "Siwa", "Qaretagnes", "Caraoasis", "Dayr", "Ziwaelbahari", "Abdannabi", "Quattara"], "culture": "egyptian_arabic"}, "Al Alamayn": {"settlements": ["Paraitonion", "Ghazal", "Shammas", "Elalamein", "Sidibarrani", "Fuka", "Katabathmos", "Mersamatruh"], "culture": "egyptian_arabic"}, "Tobruk": {"settlements": ["Tobruk", "Bardia", "Kambut", "Alqardabah", "Rukbah", "Acroma", "Zanzur", "Sollum"], "culture": "maghreb_arabic"}, "Cyrenaica": {"settlements": ["Alqubbah", "Altamimi", "Khadra", "Athrun", "Marsasusah", "Mukhayta", "Derna", "Cyrene"], "culture": "maghreb_arabic"}, "Senoussi": {"settlements": ["Kufra", "Gabr", "Tazirbu", "Jakharrah", "Buzayman", "Attallab", "Jalu", "Attaj"], "culture": "maghreb_arabic"}, "Benghazi": {"settlements": ["Benghazi", "Ajdabiya", "Barca", "Daryanah", "Jardinah", "Oriana", "Tansulukh", "Tulmaytath"], "culture": "maghreb_arabic"}, "Syrte": {"settlements": ["Syrte", "Lanuf", "Assultan", "Bishr", "Nawfalliyah", "Qaryatbishr", "Assidr", "Abuhadi"], "culture": "maghreb_arabic"}, "Westfriesland": {"settlements": ["Heerhugowaard", "Medemblik", "Texel", "Alkmaar", "Enkhuizen", "Schagen", "Egmond", "Hoorn"], "culture": "frisian"}, "Leptis Magna": {"settlements": ["Alghiran", "Leptismagna", "Naimah", "Misratah", "Alhasun", "Qirdah", "Gioda", "Abunujaym"], "culture": "maghreb_arabic"}, "Tripolitana": {"settlements": ["Mazuzah", "Aljamil", "Sabratah", "Libtripoli", "Baniwaled", "Nalut", "Funduq", "Gherlan"], "culture": "maghreb_arabic"}, "Malta": {"settlements": ["Mdina", "Sliema", "Gozo", "Sanpawl", "Marsascala", "Sangjilan", "Birzebbuga", "Mgarr"], "culture": "greek"}, "Djerba": {"settlements": ["Taguermess", "Cedriane", "Houmtsouk", "Aghir", "Ajim", "Elmey", "Abarda", "Midoun"], "culture": "maghreb_arabic"}, "Gabes": {"settlements": ["Tataouine", "Gabes", "Alqalah", "Steftimi", "Aljanain", "Medenine", "Haddej", "Kebili"], "culture": "maghreb_arabic"}, "Kairwan": {"settlements": ["Kairouan", "Meknassy", "Tozeur", "Sidibouzid", "Haffouz", "Sidimansour", "Gafsa", "Chebika"], "culture": "maghreb_arabic"}, "Mahdia": {"settlements": ["Sfax", "Neffatia", "Lacroix", "Agareb", "Msaken", "Mahdia", "Monastir"], "culture": "maghreb_arabic"}, "Tunis": {"settlements": ["Ariana", "Zaghouan", "Kelibia", "Hammamet", "Benarous", "Tunis", "Sousse", "Cartaghe"], "culture": "maghreb_arabic"}, "Medjerda": {"settlements": ["Elkrib", "Medjerda", "Qaafur", "Sidimubarak", "Dougga", "Lekef", "Kasserine", "Siliana"], "culture": "maghreb_arabic"}, "Bizerte": {"settlements": ["Netza", "Ghezala", "Almatin", "Jendouba", "Tunbeja", "Bizerte", "Tamra", "Manziljamal"], "culture": "maghreb_arabic"}, "Sticht": {"settlements": ["Buren", "Dorestad", "Woerden", "Ijsselstein", "Utrecht", "Oudewater", "Gorinchem", "Zeist"], "culture": "frisian"}, "Annaba": {"settlements": ["Eltarf", "Soukahras", "Drean", "Skikda", "Meroudj", "Elbouni", "Boudjama", "Annabah"], "culture": "maghreb_arabic"}, "Constantine": {"settlements": ["Tadjenanet", "Guelma", "Mechtakebira", "Elkhroub", "Tebessa", "Constantine", "Oumelbouaghi", "Guerrah"], "culture": "maghreb_arabic"}, "Bejaija": {"settlements": ["Elbekara", "Gantas", "Eldjabia", "Mila", "Jijel", "Boudaoud", "Setif", "Bejaija"], "culture": "maghreb_arabic"}, "Biskra": {"settlements": ["Mekhadma", "Batna", "Bigou", "Branis", "Nebka", "Biskra", "Sidiokba", "Khenchela"], "culture": "maghreb_arabic"}, "Tell Atlas": {"settlements": ["Mirabeau", "Zaoula", "Akaoudj", "Tagoughalt", "Tiziouzou", "Nacina", "Draaelmizan", "Mechreck"], "culture": "maghreb_arabic"}, "Beni Yanni": {"settlements": ["Bujima", "Tafoughalt", "Taoudouch", "Thiza", "Azeffoun", "Tigzirt", "Azazga", "Bourmedes"], "culture": "maghreb_arabic"}, "Menorca": {"settlements": ["Escastell", "Alaior", "Santlluis", "Santaagueda", "Esmercadal", "Ferreries", "Mahon"], "culture": "visigothic"}, "Mallorca": {"settlements": ["Santaponsa", "Eivissa", "Palma", "Formentera", "Manacor", "Felanitx", "Alcudia", "Algaida"], "culture": "visigothic"}, "Ouled Nail": {"settlements": ["Msila", "Beneldir", "Ainzia", "Sidinhar", "Bordjelcaid", "Sidiheg", "Tubirett", "Roumana"], "culture": "maghreb_arabic"}, "Mzab": {"settlements": ["Elbour", "Ouargla", "Zelfana", "Noumerat", "Mzab", "Elalia", "Bermane", "Sebseb"], "culture": "maghreb_arabic"}, "Gelre": {"settlements": ["Zwolle", "Deventer", "Zutphen", "Bronckhorst", "Bergh", "Arnhem", "Nijmegen", "Kampen"], "culture": "frisian"}, "Lemdiyya": {"settlements": ["Aintorki", "Aindefla", "Blida", "Sidimohammed", "Relizane", "Medea", "Elhachem", "Elrhenb"], "culture": "maghreb_arabic"}, "Al Djazair": {"settlements": ["Tipasa", "Algiers", "Rhedadoua", "Elachour", "Chiffa", "Elrdair", "Sidiakacha", "Tirourda"], "culture": "maghreb_arabic"}, "Orania": {"settlements": ["Oran", "Mostaganem", "Gdyel", "Merselhadjad", "Ainelberd", "Aintemouchent", "Benisaf", "Maghnia"], "culture": "maghreb_arabic"}, "Atlas Mnt": {"settlements": ["Ainzmila", "Bordj", "Ainrich", "Tiaret", "Elyourh", "Hassibenmadjeb", "Djelfa", "Selmana"], "culture": "maghreb_arabic"}, "Tlemcen": {"settlements": ["Tlemcen", "Bedrabine", "Tessala", "Letelagh", "Elhaicaiba", "Dhaya", "Muaskar", "Sidibelabbes"], "culture": "maghreb_arabic"}, "Hanyan": {"settlements": ["Alancha", "Hanyan", "Magoura", "Raselma", "Saida", "Alkasdir", "Naama", "Bougtob"], "culture": "maghreb_arabic"}, "Snassen": {"settlements": ["Ahfir", "Berkane", "Jerada", "Oujda", "Debdou", "Tendrara", "Ainbenimathar", "Saldia"], "culture": "maghreb_arabic"}, "Figuig": {"settlements": ["Benitajjit", "Boudnib", "Figuig", "Ainechchair", "Bouarfa", "Bechar", "Ich", "Safsaf"], "culture": "maghreb_arabic"}, "El Rif": {"settlements": ["Midar", "Melilla", "Ketama", "Geurcif", "Saka", "Nador", "Driouch", "Alhoceima"], "culture": "maghreb_arabic"}, "Cebta": {"settlements": ["Targuist", "Martil", "Babtaza", "Mdiq", "Aulef", "Tetouan", "Cueta", "Xauen"], "culture": "maghreb_arabic"}, "Frisia": {"settlements": ["Harlingen", "Bolsward", "Leeuwarden", "Stavoren", "Dokkum", "Assen", "Franeker", "Groningen"], "culture": "frisian"}, "Fes": {"settlements": ["Elhajeb", "Zerhoun", "Sefrou", "Bouanane", "Fes", "Missour", "Meknes", "Enjil"], "culture": "maghreb_arabic"}, "Tangiers": {"settlements": ["Charkia", "Tangiers", "Mulaybuselham", "Alcazarquivir", "Barrha", "Laraiche", "Ainbenamar", "Asilah"], "culture": "maghreb_arabic"}, "Infa": {"settlements": ["Azemmour", "Tiflet", "Infa", "Berrechid", "Oulmes", "Sale", "Khouribga", "Rabat"], "culture": "maghreb_arabic"}, "Marrakech": {"settlements": ["Demnat", "Alnif", "Ouarzazate", "Marrakech", "Elanakir", "Thineghir", "Asni", "Sidirahhal"], "culture": "maghreb_arabic"}, "Massat": {"settlements": ["Agouidir", "Aguedal", "Haddraa", "Safi", "Qumelaioun", "Aitelaouni", "Akermoud", "Essaouira"], "culture": "maghreb_arabic"}, "Anti-Atlas": {"settlements": ["Biourga", "Tata", "Argana", "Agadir", "Kasbaeljoua", "Illrh", "Taroudaut", "Alogoum"], "culture": "maghreb_arabic"}, "Ifni": {"settlements": ["Tiznit", "Mihrleft", "Belkassem", "Guelmim", "Tizgui", "Ifni", "Rgab", "Ouaouteit"], "culture": "maghreb_arabic"}, "Tharasset": {"settlements": ["Amot", "Tiglit", "Tantan", "Tharasset", "Tartaya", "Akhfennir", "Tidergit", "Chbika"], "culture": "maghreb_arabic"}, "Bremen": {"settlements": ["Verden", "Achim", "Blumenthal", "Ritzebuttel", "Beverstedt", "Stade", "Bremen", "Hoya"], "culture": "old_saxon"}, "Canarias": {"settlements": ["Alegranza", "Lapalma", "Fuerteventura", "Lanzarote", "Grancanaria", "Lagomera", "Tenerife", "Lagraciosa"], "culture": "maghreb_arabic"}, "Ostfriesland": {"settlements": ["Wittmund", "Leer", "Borkum", "Norden", "Aurich", "Emden", "Norderney", "Esens"], "culture": "frisian"}, "Kandalax": {"settlements": ["Sarapo", "Pyaozero", "Ponoy", "Kantalahti", "Kolsky", "Umba", "Lekastrom", "Varzuga"], "culture": "lappish"}, "Capua": {"settlements": ["Gaeta", "Calvi", "Capua", "Montecassino", "Acerra", "Teano", "Caserta"], "culture": "lombard"}, "Zahedan": {"settlements": ["Kacharud", "Khajeh", "Buk", "Golchah", "Hamun", "Jahangir", "Zahedan", "Kuhtaftan"], "culture": "baloch"}, "Bam": {"settlements": ["Abeshkan", "Kaj", "Nukjub", "Bal Chah", "Bampur", "Baravat", "Fahraj", "Sol Hasan"], "culture": "persian"}, "Jask": {"settlements": ["Hara Gabrik", "Band Jask", "Miski", "Zaharai", "Par Kun", "Rabag", "Yeldar", "Jagin"], "culture": "baloch"}, "Zamindawar": {"settlements": ["Zamindawar", "Bishlang", "Khalai"], "culture": "afghan"}, "Mahra": {"settlements": ["Haswayn", "Qishn", "Damqwat", "Alhalya", "Alkurah", "Nishtun", "Ghaydah", "Itab"], "culture": "bedouin_arabic"}, "Kathiri": {"settlements": ["Lodar", "Mukalla", "Shabwa", "Seiyun", "Qana", "Nisab", "Azzan", "Shihar"], "culture": "bedouin_arabic"}, "Bayda": {"settlements": ["Habban", "Alkhabr", "Timna", "Bayda", "Zinjibar", "Ataq", "Ashshubaykah", "Yashbum"], "culture": "bedouin_arabic"}, "Aden": {"settlements": ["Alarbadi", "Dhala", "Alawbhali", "Almilah", "Jaar", "Alkawd", "Aden", "Lahej"], "culture": "bedouin_arabic"}, "Taizz": {"settlements": ["Perim", "Jibla", "Ibb", "Shuqra", "Mocha", "Zafar", "Taizz", "Dhisufal"], "culture": "bedouin_arabic"}, "Oldenburg": {"settlements": ["Varel", "Nordenham", "Jever", "Loningen", "Delmenhorst", "Kniphausen", "Cloppenburg", "Oldenburg"], "culture": "old_saxon"}, "Sanaa": {"settlements": ["Jabaltiyal", "Dhamar", "Qataba", "Jabalannabishuayb", "Hodeida", "Marib", "Harib", "Sanaa"], "culture": "bedouin_arabic"}, "Asir": {"settlements": ["Kuthba", "Kamaran", "Hajjah", "Sadah", "Tabala", "Dam", "Bahah"], "culture": "bedouin_arabic"}, "Halaban": {"settlements": ["Arradum", "Aljammaniyah", "Alqaiyah", "Albijadiyah", "Albaharah", "Badaiidyan", "Almaklah"], "culture": "bedouin_arabic"}, "Hajr": {"settlements": ["Baljurashi", "Bisha", "Jizan", "Khamismushait", "Almaqah", "Abha", "Alhudaydah"], "culture": "bedouin_arabic"}, "Hail": {"settlements": ["Asshinan", "Iqdah", "Mawqaq", "Murayfiq", "Baqa", "Alghazalah", "Saban"], "culture": "levantine_arabic"}, "Rafha": {"settlements": ["Uwayqilah", "Markuz", "Ashshir", "Timiat", "Lawqah", "Aljumaymah", "Duwayd"], "culture": "levantine_arabic"}, "Dhofar": {"settlements": ["Raysut", "Durrah", "Shisr", "Salalah", "Harzan", "Amal", "Dawkah", "Thamarit"], "culture": "bedouin_arabic"}, "Duqm": {"settlements": ["Aljazir", "Masirah", "Hubara", "Nimr", "Duqm", "Harima", "Mahut", "Bank", "Nizwa"], "culture": "bedouin_arabic"}, "Muscat": {"settlements": ["Lizq", "Shiya", "Ibra", "Samail", "Adam", "Muscat", "Sur", "Sabt"], "culture": "bedouin_arabic"}, "Hajar": {"settlements": ["Alhamra", "Ibri", "Jabrin", "Suhar", "Masruq", "Haran", "Yanqui"], "culture": "bedouin_arabic"}, "Osnabruck": {"settlements": ["Bentheim", "Tecklenburg", "Meppen", "Lingen", "Quackenbruck", "Wildeshausen", "Minden", "Osnabruck"], "culture": "old_saxon"}, "Dhu Zabi": {"settlements": ["Julfar", "Qutuf", "Dubai", "Sharjah", "Sohar", "Dibba", "Khorfakkan", "Dhuzabi"], "culture": "bedouin_arabic"}, "Busaso": {"settlements": ["Garoowe", "Lasanod", "Qardho", "Erigavo", "Bandaraassim", "Buraan", "Hadaftimo", "Mosylon"], "culture": "somali"}, "Berbera": {"settlements": ["Burco", "Shiikh", "Mandera", "Gabiley", "Maydh", "Daarbuduq", "Berbera"], "culture": "somali"}, "Harer": {"settlements": ["Harar", "Alemaya", "Kurfachele", "Dakkar", "Kombolcha", "Babile", "Diridawa"], "culture": "ethiopian"}, "Tadjoura": {"settlements": ["Tadjoura", "Randa", "Obock", "Holhol", "Djibouti", "Dikhil", "Berenice"], "culture": "somali"}, "Aksum": {"settlements": ["Mekele", "Adigrat", "Adwa", "Hawzen", "Rama", "Yeha"], "culture": "ethiopian"}, "Akordat": {"settlements": ["Akordat", "Mogolo", "Shambuko", "Barentu", "Dghe", "Teseney", "Antalla"], "culture": "ethiopian"}, "Kassala": {"settlements": ["Doka", "Gherset", "Kagnarti", "Aroma", "Tebteb", "Dinder"], "culture": "nubian"}, "Hayya": {"settlements": ["Taris", "Kataigarsa", "Gebeit", "Musmer", "Aliab", "Sinkat"], "culture": "nubian"}, "Atbara": {"settlements": ["Atbara", "Begarawiyah", "Hajaralasla", "Ummmardi", "Abudis", "Meruwah", "Shendi"], "culture": "nubian"}, "Munster": {"settlements": ["Steinfurt", "Dortmund", "Essen", "Gronau", "Ahlen", "Munster", "Gutersloh", "Greven"], "culture": "old_saxon"}, "Sennar": {"settlements": ["Sennar", "Galgani", "Sinjah", "Bakkah", "Abbeit", "Kukur", "Wadrawah"], "culture": "nubian"}, "Asosa": {"settlements": ["Kormuk", "Debrezeyit", "Genetemariam", "Ketema", "Asosa", "Mankush", "Bambasi", "Dibate"], "culture": "ethiopian"}, "Ankober": {"settlements": ["Berehet", "Tegulet", "Keyagebriel", "Saqqa", "Doqaqit", "Qundi", "Aliyuamba"], "culture": "ethiopian"}, "Gondar": {"settlements": ["Fasilghebbi", "Bahirdar", "Magdala", "Roha", "Dembiya", "Tanaqirqos", "Ambassel", "Gondar"], "culture": "ethiopian"}, "Antalo": {"settlements": ["Bale", "Oromos", "Debrelibanos", "Debreberhan", "Antsokia", "Shewa", "Entoto", "Hayq"], "culture": "ethiopian"}, "Matamma": {"settlements": ["Yadeta", "Chiri", "Ginbo", "Gishabay", "Bonga", "Garo", "Kaffa", "Wacha"], "culture": "ethiopian"}, "Perm": {"settlements": ["Chemuska", "Yagoshikha", "Biser", "Cherdyn", "Gorodki", "Lysva"], "culture": "komi"}, "Yamalia": {"settlements": ["Obdorsk", "Urengoi", "Kaek", "Lapytnangk", "Nazym", "Baygul", "Ituyakha"], "culture": "khanty"}, "Komi": {"settlements": ["Ustkolom", "Vorkuta", "Vorgashor", "Khalmeryu", "Kharp", "Aykino", "Usttsilma"], "culture": "komi"}, "Ural": {"settlements": ["Satka", "Kaslinsky", "Ustkatav", "Kyshtym", "Asha", "Miass", "Chebarkul"], "culture": "komi"}, "Kleve": {"settlements": ["Rees", "Kleve", "Emmerich", "Wesel", "Xanten", "Isselburg", "Goch", "Anholt"], "culture": "german"}, "Khantia": {"settlements": ["Pnobe", "Beloyarskiy", "Berezovo", "Djinesh", "Nyagyn", "Sherkala", "Igrim"], "culture": "khanty"}, "Tyumen": {"settlements": ["Tugulym", "Qashliq", "Novtap", "Sumkino", "Nizhtavda", "Borovskiy", "Tobolsk"], "culture": "cuman"}, "Mansia": {"settlements": ["Pytyakh", "Poykovskiy", "Nefteyugansk", "Yalbak", "Yabin", "Mamontovo"], "culture": "khanty"}, "Sibir": {"settlements": ["Baduk", "Belyyyar", "Kaik", "Vysokiy", "Surgut", "Langepas", "Iberbolgar", "Pokachi"], "culture": "khanty"}, "Saravan": {"settlements": ["Pahrah", "Sarbaz", "Jaleq", "Khash", "Sangan", "Pishin", "Saravan", "Rasak"], "culture": "baloch"}, "Yaik": {"settlements": ["Vagay", "Shumikha", "Mishkino", "Kyzalyar", "Makushino", "Lebyazhe", "Yurgamysh"], "culture": "cuman"}, "Aqtobe": {"settlements": ["Shilikta", "Kunsay", "Zharlysay", "Ashchesay", "Sibiryak", "Aulkutyrtas"], "culture": "cuman"}, "Inder": {"settlements": ["Dzhanatalap", "Kaumetey", "Karatogay", "Bogunbay", "Kemer", "Chausay", "Ebita"], "culture": "cuman"}, "Tobol": {"settlements": ["Tyukalinsk", "Tara", "Kalachinsk", "Krasnyyar", "Isilkul", "Sargatka", "Cherlak"], "culture": "cuman"}, "Tis": {"settlements": ["Regedan", "Pozm Machchan", "Sergen", "Kursar", "Parak", "Tis", "Chabahar", "Konarak"], "culture": "baloch"}, "Connacht": {"settlements": ["Roscommon", "Anchory", "Killala", "Tuam", "Elphin", "Galway", "Clonfert", "Mayo"], "culture": "irish"}, "Julich": {"settlements": ["Prum", "Geldern", "Moers", "Monschau", "Aachen", "Roermond", "Duren", "Julich"], "culture": "old_frankish"}, "Syr Darya": {"settlements": ["Kazaly", "Kyzylorda", "Dzhanadzhol", "Zhalagash", "Akmechet", "Terenuzyak", "Sarytogay"], "culture": "turkish"}, "Kyzylkum": {"settlements": ["Shovot", "Bogot", "Xazorasp", "Itchankila", "Qorovul", "Yangiariq", "Xonqa"], "culture": "turkish"}, "Dashhowuz": {"settlements": ["Akdepe", "Boldumsaz", "Gorogly", "Tagta", "Gubadag", "Kunyaurgench", "Dashhowuz", "Yylanly"], "culture": "persian"}, "Samarkand": {"settlements": ["Urgut", "Ziadin", "Afrasiyab", "Khokand", "Laish", "Ishtikhon", "Samarkand", "Koshrabot"], "culture": "sogdian"}, "Balkh": {"settlements": ["Alkhanoum", "Dalverzintepe", "Balkh", "Tiliatepe", "Surkhkotal"], "culture": "persian"}, "Herat": {"settlements": ["Chishti", "Farsi", "Herat", "Kushk", "Zarghun", "Karukh", "Gulran", "Obe"], "culture": "persian"}, "Birjand": {"settlements": ["Furg", "Birjand", "Sarayan", "Qaen", "Boshruyeh", "Paeenshahr", "Toon", "Nehbandan"], "culture": "persian"}, "Mandesh": {"settlements": ["Gozareh", "Saghar", "Baluci", "Kwajaha", "Chaghcharan", "Taywara", "Adraskan"], "culture": "persian"}, "Loon": {"settlements": ["Tongeren", "Loon", "Hasselt", "Heinsberg", "Hesbaie", "Wassenberg", "Maastricht", "Valkenburg"], "culture": "old_frankish"}, "Timbuktu": {"settlements": ["Salam", "Toya", "Aglal", "Timbuktu", "Ber", "Lafia"], "culture": "manden"}, "Aoudaghost": {"settlements": ["Tichitt", "Moudjeria"], "culture": "manden"}, "Ghana": {"settlements": ["Koumbi Saleh", "Singhanah", "El Ghaba", "Silla"], "culture": "manden"}, "Gao": {"settlements": ["Gao", "Anchawadi", "Gabero", "Bourem", "Ansongo"], "culture": "manden"}, "Djenne": {"settlements": ["Derary", "Djenne", "Fakala", "Macina", "Femaye"], "culture": "manden"}, "Taghaza": {"settlements": ["Kerzaz", "Aougrout", "Charouine", "Reggane", "Metarta", "Adrar"], "culture": "maghreb_arabic"}, "Araouane": {"settlements": ["Tazrouk", "Tessalit", "Tamanrasset", "Abalessa", "Guezzam", "Aguelhok", "Tinzaouten"], "culture": "maghreb_arabic"}, "Sijilmasa": {"settlements": ["Merzane", "Tanamouste", "Tadaout", "Tisserdmine", "Ertoud", "Sijilmasa", "Hannabou", "Merzouga"], "culture": "maghreb_arabic"}, "Oualata": {"settlements": ["Tiguiguil", "Tarhalet", "Fassekra", "Konou", "Tizert"], "culture": "manden"}, "Breda": {"settlements": ["Willemstad", "Breda", "Ravenstein", "Bergenopzoom", "Cuijck", "Shertogenbosch", "Horn"], "culture": "old_frankish"}, "Ouadane": {"settlements": ["Azuggi"], "culture": "maghreb_arabic"}, "Idjil": {"settlements": ["Tazadit", "Rouessa"], "culture": "maghreb_arabic"}, "Tadmekka": {"settlements": ["Essako", "Kidal", "Takedda", "Agades"], "culture": "manden"}, "Mali": {"settlements": ["Niani", "Bougouni", "Baguineda", "Bamako", "Safo", "Soussa", "Boure", "Dialakoro"], "culture": "manden"}, "Bambuk": {"settlements": ["Boumdeid", "Bambuk", "Kankossa", "Aftout", "Guerou", "Kiffa"], "culture": "manden"}, "Zarma": {"settlements": ["Bura", "Ouallam", "Tera"], "culture": "manden"}, "Gurma": {"settlements": ["Zorgho", "Hounde", "Gurma"], "culture": "manden"}, "Aprutium": {"settlements": ["Chieti", "Pescara", "Avezzano"], "culture": "lombard"}, "Gent": {"settlements": ["St Niklaas", "Dendermonde", "Oudenaarde", "Aalst", "Kortrijk", "Gent", "Geraarsbergen", "Doornik"], "culture": "old_frankish"}, "Bar": {"settlements": [], "culture": "old_frankish"}, "More": {"settlements": ["Kalmar Hus", "Kalmar"], "culture": "norse"}, "Tjust": {"settlements": ["Tornsfall", "Vastervik"], "culture": "norse"}, "Roslavl": {"settlements": ["Roslavl", "Chocimsk", "Pochinok"], "culture": "severian"}, "Lepiel": {"settlements": ["Chashniki", "Novolukoml", "Lepiel"], "culture": "ilmenian"}, "Amalfi": {"settlements": ["Ravello", "Sorrento", "Tramonti", "Amalfi"], "culture": "greek"}, "Hainaut": {"settlements": ["Valenciennes", "Mons", "Enghien", "Charleroi", "Avesnes", "Ath", "Cambrai", "Chievres"], "culture": "old_frankish"}, "Amiens": {"settlements": ["Soissons", "Peronne", "Montdidier", "Breteuil", "Corbie", "Amiens", "Beauvais", "Noyon"], "culture": "old_frankish"}, "Eu": {"settlements": ["Neufchatel-En-Bray", "Forges", "Aumale", "Mortemer", "Serqueux", "Gournay", "Eu", "Drincourt"], "culture": "old_frankish"}, "Arques": {"settlements": ["Rouen", "Lillebonne", "Fecamp", "Arques"], "culture": "old_frankish"}, "Vexin": {"settlements": ["Mantes", "Harcourt", "Abbayedemortemer", "Larocheguyon", "Louviers", "Ivry", "Gisors", "Pontoise"], "culture": "old_frankish"}, "Evreux": {"settlements": ["Argentan", "Sees", "Alencon", "Falaise", "Lisieux", "Evreux", "Honfleur", "Verneuil"], "culture": "old_frankish"}, "": {"settlements": [], "culture": ""}}
+{
+    "Vestisland": {
+        "settlements": ["Skalholt", "Borg", "Alftanes", "Kjalarnes", "Hlidarendi", "Reykjavik", "Hvamm", "Pingvellir"],
+        "culture": "norse"
+    },
+    "Kildare": {
+        "settlements": ["Clonard", "Knockaulin", "Kildare", "Durrow", "Rathangan", "Athlone", "St Brigit", "Maynooth"],
+        "culture": "irish"
+    },
+    "Avranches": {
+        "settlements": ["Mortain", "Bayeux", "Cherbourg", "Avranches", "Barfleur", "Coutances", "Domfront", "Caen"],
+        "culture": "old_frankish"
+    },
+    "Rennes": {
+        "settlements": ["Dol", "Porhoet", "St Meen", "Dinan", "St Malo", "Rennes", "St Michel"],
+        "culture": "breton"
+    },
+    "Lori": {
+        "settlements": ["Dzegh", "Dmanis", "Lori Berd"],
+        "culture": "georgian"
+    },
+    "Penthievre": {
+        "settlements": ["Peran", "Quintin", "Chatelaudren", "St Brieuc", "Monkontour", "Loudeac", "Verdelet", "Paimpol"],
+        "culture": "breton"
+    },
+    "French Leon": {
+        "settlements": ["Roscoff", "Guingamp", "St Pol De Leon", "Brest", "Morlaix", "Treguier", "Plourivo", "Plougonven"],
+        "culture": "breton"
+    },
+    "Cornouaille": {
+        "settlements": ["Landevennec", "Quimper", "Huelgoat", "Carhaix", "Quimperle", "Lezergue", "Corlay", "Langonnet"],
+        "culture": "breton"
+    },
+    "Vannes": {
+        "settlements": ["Pontivy", "Locmine", "Vannes", "Suscinio", "Auray", "Josselin", "Hennebont"],
+        "culture": "breton"
+    },
+    "Nantes": {
+        "settlements": ["Guerande", "Chateaubriant", "La Roche-Bernard", "St Nazaire", "Donges", "Redon", "Nantes", "Clisson"],
+        "culture": "breton"
+    },
+    "Anjou": {
+        "settlements": ["Treves", "Fontevraud", "Angers", "Saumur", "Chateaugontier", "Montsoreau", "Cholet"],
+        "culture": "old_frankish"
+    },
+    "Maine": {
+        "settlements": ["Evron", "Craon", "Le Mans", "Mayenne", "Sable", "Laval", "Beaumont"],
+        "culture": "old_frankish"
+    },
+    "Vendome": {
+        "settlements": ["Montmirail", "Freteval", "Montoire", "Cloyes", "Lavardin", "Chateaurenault", "Stavit", "Vendome"],
+        "culture": "old_frankish"
+    },
+    "Dublin": {
+        "settlements": ["Ath Cliath", "Clondalkin", "Mellifont", "Wicklow", "Trim", "Christ Church", "Dublin", "Finglas"],
+        "culture": "irish"
+    },
+    "Blois": {
+        "settlements": ["Chaumontsurloire", "Montrichard", "Stgeorgesdubois", "Staignan", "Romorantin", "Blois", "Fougeressurbievre"],
+        "culture": "old_frankish"
+    },
+    "Chartres": {
+        "settlements": ["Nogent", "Chartres", "Tiron", "Gallardon", "Chateaudun", "Bonneval", "Epernon"],
+        "culture": "old_frankish"
+    },
+    "Madurai": {
+        "settlements": ["Srivilliputtur", "Madurai", "Tiruparankunram", "Anaimalai", "Kilakarai", "Ramesvaram", "Ramnadhapuram"],
+        "culture": "tamil"
+    },
+    "Chagai": {
+        "settlements": ["Nushki"],
+        "culture": "baloch"
+    },
+    "Mahoyadapuram": {
+        "settlements": ["Kaviyur", "Kunjakari", "Kadungallur", "Tripunittura", "Kaladi", "Mahoyadapuram", "Udagai"],
+        "culture": "tamil"
+    },
+    "Cholamandalam": {
+        "settlements": ["Kannanur", "Nagapattinam", "Tanjavur", "Kumbhakarna", "Srirangam", "Gangaikondacolapuram", "Tiruccirapalli", "Mannargudi", "Citambaram", "Jambukesvara", "Aon Amaravati", "Uraiyur"],
+        "culture": "tamil"
+    },
+    "Tenkasi": {
+        "settlements": ["Dindigul", "Tirumalapuram", "Tenkasi", "Palayamcottai", "Sankaranayinarkovil", "Aivarmalai"],
+        "culture": "tamil"
+    },
+    "Qalqut": {
+        "settlements": ["Chaliyam", "Kannur", "Vatakara", "Calicut", "Parappanangadi", "Urakam", "Nediyiruppu"],
+        "culture": "tamil"
+    },
+    "Manyapura": {
+        "settlements": ["Kikkeri", "Aralaguppe", "Govindanahalli", "Basaralu", "Melukote", "Manyapura", "Turuvekere"],
+        "culture": "kannada"
+    },
+    "Kanchipuram": {
+        "settlements": ["Kanchipuram", "Koodalur", "Rajagiri", "Alampuravi", "Takkaloma", "Mailapur", "Uttaramerur"],
+        "culture": "tamil"
+    },
+    "Ile De France": {
+        "settlements": ["Paris", "Melun", "Meaux", "Stdenis", "Montfortlamaury", "Compiegne"],
+        "culture": "old_frankish"
+    },
+    "Tagadur": {
+        "settlements": ["Tagadur", "Satyamangalam", "Tirukkovalur", "Jinji", "Padaividu", "Siyyamangalam", "Tiruvannamalai"],
+        "culture": "tamil"
+    },
+    "Uchangidurga": {
+        "settlements": ["Harihar", "Nidugallu", "Uchangidurga", "Hemavati", "Chitradurga", "Parivi", "Sira"],
+        "culture": "kannada"
+    },
+    "Udayagiri": {
+        "settlements": ["Vallurapura", "Srisailam", "Mahanandi", "Kanipakam", "Sriparvata", "Udayagiri", "Gandikota", "Nandyal"],
+        "culture": "telugu"
+    },
+    "Vengipura": {
+        "settlements": ["Bandarulanka", "Narasapuram", "Palakollu", "Vengipura", "Eluru", "Dwarakatirumala", "Kondapalli"],
+        "culture": "telugu"
+    },
+    "Honnore": {
+        "settlements": ["Bhatkal", "Barkur", "Honnore", "Mookambika", "Karwar", "Gokarna"],
+        "culture": "kannada"
+    },
+    "Thana": {
+        "settlements": ["Janjira", "Bassein", "Thana", "Mahim", "Dabhol", "Kanhagiri", "Chaul"],
+        "culture": "marathi"
+    },
+    "Daman": {
+        "settlements": ["Bulsar", "Sanjan", "Ramnagar", "Daman", "Nagar Haveli", "Surparaka", "Pardi"],
+        "culture": "gujurati"
+    },
+    "Navasarika": {
+        "settlements": ["Surat", "Rander", "Navasarika", "Akruresvara", "Tadkeshwar", "Variav", "Dharampur", "Rajpipla", "Bharuch"],
+        "culture": "gujurati"
+    },
+    "Vizagipatam": {
+        "settlements": ["Simhachalam", "Anakapalle", "Kotipalli", "Bheemunipatnam", "Bavikonda", "Vizagipatam"],
+        "culture": "telugu"
+    },
+    "Kataka": {
+        "settlements": ["Athgarh", "Sakshigopal", "Katak", "Bhubaneswar", "Dhauli", "Sarala", "Konarak"],
+        "culture": "oriya"
+    },
+    "Vermandois": {
+        "settlements": ["Montaigu", "Coucy", "Guise", "Crepy", "Laon", "Stquentin", "Signy", "Rethel"],
+        "culture": "old_frankish"
+    },
+    "Mandavyapura": {
+        "settlements": ["Mandavyapura", "Naddula", "Osian", "Sanderaka", "Mathania", "Siwana", "Ghaneraov"],
+        "culture": "rajput"
+    },
+    "Karmanta": {
+        "settlements": ["Mainamati", "Udaipur", "Unakoti", "Karmanta"],
+        "culture": "bengali"
+    },
+    "Kirghiz": {
+        "settlements": ["Abakan"],
+        "culture": "kirghiz"
+    },
+    "Vadodara": {
+        "settlements": ["Vadodara", "Ankotakka", "Darbhavati", "Vatpatrak", "Kayavarohan", "Nasvadi"],
+        "culture": "gujurati"
+    },
+    "Bhumilka": {
+        "settlements": ["Bhavnat", "Mangrol", "Shrinagar", "Vamanasthali", "Bhumilka", "Uperkot"],
+        "culture": "gujurati"
+    },
+    "Valabhi": {
+        "settlements": ["Palatina", "Shatrunjaya", "Valabhi", "Dhandhuka", "Sihor", "Gundigar"],
+        "culture": "gujurati"
+    },
+    "Dvaraka": {
+        "settlements": ["Gomati", "Bhanvad", "Dvaraka", "Lalpur"],
+        "culture": "gujurati"
+    },
+    "Mansura": {
+        "settlements": ["Hala", "Mirman", "Mirpur Khas", "Matiari", "Nasarpur", "Mansura", "Nerunkot"],
+        "culture": "sindhi"
+    },
+    "Bhakkar": {
+        "settlements": ["Sarkara", "Atri", "Bhakkar", "Kalari", "Larkana", "Shikarpur"],
+        "culture": "sindhi"
+    },
+    "Makran": {
+        "settlements": ["Kiz", "Ormara", "Al Haur", "Kannazbun"],
+        "culture": "baloch"
+    },
+    "Reims": {
+        "settlements": ["Chatillon", "Roucy", "Provins", "Vertus", "Epernay", "Chalons", "Chateauthierry", "Reims"],
+        "culture": "old_frankish"
+    },
+    "Banavasi": {
+        "settlements": ["Vankapura", "Ikkeri", "Sringeri", "Kuruvatti", "Lakkundi", "Hangal", "Candragutti", "Vaijayanti", "Balligavi"],
+        "culture": "kannada"
+    },
+    "Kol": {
+        "settlements": ["Kol", "Nilavati", "Etah", "Soron", "Barauli", "Dor"],
+        "culture": "hindustani"
+    },
+    "Pratishthana": {
+        "settlements": ["Patkapur", "Harishchandragad", "Bhingar", "Pratishthana", "Ahmednagar", "Chambargonda"],
+        "culture": "marathi"
+    },
+    "Kalyani": {
+        "settlements": ["Hanakuni", "Kalyani", "Narayanapur", "Ausa", "Umapur"],
+        "culture": "kannada"
+    },
+    "Kollipake": {
+        "settlements": ["Kollipake", "Karmanghat", "Chilkur Balaji", "Devaryamjal", "Golkonda"],
+        "culture": "telugu"
+    },
+    "Devagiri": {
+        "settlements": ["Sillod", "Grishneshwar", "Khuldabad", "Vaijapur", "Devagiri"],
+        "culture": "marathi"
+    },
+    "Naldurg": {
+        "settlements": ["Tuljapur", "Karmala", "Dharaseo", "Paranda", "Naldurg", "Sonnalagi"],
+        "culture": "marathi"
+    },
+    "Mandapika": {
+        "settlements": ["Mandapika", "Borgarh", "Maheshwar", "Avasgarh", "Bawangaja"],
+        "culture": "hindustani"
+    },
+    "Dasapura": {
+        "settlements": ["Hinglajgarh", "Taxakeshwar", "Dharmrajeshwar", "Dasapura", "Sondani"],
+        "culture": "rajput"
+    },
+    "Dhara": {
+        "settlements": ["Dharampuri", "Indore", "Jobat", "Sailana", "Betma", "Depalpur", "Dhara"],
+        "culture": "hindustani"
+    },
+    "Luxembourg": {
+        "settlements": ["Luxembourg", "Differdange", "Arlon", "Ettelbruck", "Neufchateau", "Bouillon", "Saintvith", "Longwy"],
+        "culture": "old_frankish"
+    },
+    "Sarangpur": {
+        "settlements": ["Rajgarh", "Ashta", "Jhalawar", "Gagraun", "Sidhhapur", "Sarangpur"],
+        "culture": "hindustani"
+    },
+    "Laksmanavati": {
+        "settlements": ["Gaur", "Shukla", "Pankak", "Banan", "Puthia", "Malda", "Laksmanavati"],
+        "culture": "bengali"
+    },
+    "Mudgagiri": {
+        "settlements": ["Kahalgaon", "Campa", "Mudgagiri", "Vikramasila", "Jahnugiri", "Karnagarh", "Lakhisarai"],
+        "culture": "bengali"
+    },
+    "Kotivarsa": {
+        "settlements": ["Korat", "Jagaddala", "Bangarh", "Devkot", "Siliguri", "Ramavati"],
+        "culture": "bengali"
+    },
+    "Magadha": {
+        "settlements": ["Rajagrha", "Odantapuri", "Triveni", "Barh", "Pataliputra", "Maner", "Bihar Sharif"],
+        "culture": "bengali"
+    },
+    "Sripuri": {
+        "settlements": ["Nuapada", "Bagbahara", "Sripuri", "Basna", "Rajiva Lochana"],
+        "culture": "oriya"
+    },
+    "Kodalaka Mandala": {
+        "settlements": ["Talcher", "Joranda Gadhi", "Bajrakot", "Deogarh", "Karamul", "Kapilash", "Kodalaka", "Dhenkanal"],
+        "culture": "oriya"
+    },
+    "Balkonda": {
+        "settlements": ["Nirmal", "Balkonda", "Manikdurg", "Mahur", "Dharmapuri", "Basara"],
+        "culture": "telugu"
+    },
+    "Bidar": {
+        "settlements": ["Tekadee", "Bhatambra", "Kamthana", "Bidar", "Avarwadi", "Jalasangvi", "Bhalki"],
+        "culture": "kannada"
+    },
+    "Ramagiri": {
+        "settlements": ["Ramagiri", "Nandivardhana", "Mansar", "Pavnar"],
+        "culture": "marathi"
+    },
+    "Liege": {
+        "settlements": ["Cine", "Namur", "Liege", "Bastogne", "Huy", "Stavelot", "Salm", "Laroche"],
+        "culture": "old_frankish"
+    },
+    "Rayapura": {
+        "settlements": ["Shivapura", "Shivadurga", "Rayapura", "Nandgram", "Rajim"],
+        "culture": "oriya"
+    },
+    "Kasmira": {
+        "settlements": ["Shankaracharya", "Parihasapura", "Srinagara", "Padmapura", "Baghsar", "Amaresvara", "Loharakota"],
+        "culture": "panjabi"
+    },
+    "Kusinagara": {
+        "settlements": ["Chapra", "Kusinagara", "Padrauna", "Pava", "Ramagrama"],
+        "culture": "bengali"
+    },
+    "Varanasi": {
+        "settlements": ["Bhadohi", "Kashi Vishwanath", "Ballia", "Durga Mandir"],
+        "culture": "hindustani"
+    },
+    "Chauragarh": {
+        "settlements": ["Chauragarh", "Barman", "Bohani"],
+        "culture": "hindustani"
+    },
+    "Bandhugadha": {
+        "settlements": ["Bahoriband", "Virateshwar", "Shahdol", "Bandhugadha"],
+        "culture": "hindustani"
+    },
+    "Jaunpur": {
+        "settlements": ["Tanda", "Gadhipuri", "Haldi", "Dohrighat", "Amethi", "Kerarkot", "Jaunpur"],
+        "culture": "hindustani"
+    },
+    "Lakhnau": {
+        "settlements": ["Hardoi", "Zaidpur", "Satrikh", "Lakhnau", "Jasnaul"],
+        "culture": "hindustani"
+    },
+    "Katehar": {
+        "settlements": ["Mandawar", "Bijnor", "Nehtaur", "Gangadvara", "Jageshwar", "Rishikesh"],
+        "culture": "hindustani"
+    },
+    "Kalpi": {
+        "settlements": ["Kalpi", "Lahar", "Jalaun", "Oirai", "Konch", "Kurara"],
+        "culture": "hindustani"
+    },
+    "Brabant": {
+        "settlements": ["Grimbergen", "Herstal", "Aarschot", "Mechelen", "Leuven", "Antwerpen", "Brussel", "Lier"],
+        "culture": "old_frankish"
+    },
+    "Vidisa": {
+        "settlements": ["Bhojpur", "Bijamandal", "Vidisa", "Mangla Devi", "Raisin", "Sironj"],
+        "culture": "hindustani"
+    },
+    "Kalanjara": {
+        "settlements": ["Devendranagar", "Bhatta", "Jayapura", "Khajuraho", "Panna", "Kalinjar"],
+        "culture": "hindustani"
+    },
+    "Gwalior": {
+        "settlements": ["Sahastrabahu", "Gwalior", "Sabalgarh", "Vijaypur", "Narwar", "Dabra", "Bateshwar"],
+        "culture": "hindustani"
+    },
+    "Sambhal": {
+        "settlements": ["Tattandapura", "Amroha", "Ujhani", "Sirsi", "Sambhal", "Bachhraon"],
+        "culture": "hindustani"
+    },
+    "Godwad": {
+        "settlements": ["Jalor", "Candravati", "Barodiya", "Khudala", "Achalgarh"],
+        "culture": "rajput"
+    },
+    "Aror": {
+        "settlements": ["Allah Abad", "Chak", "Aror", "Siraj Ji Takri", "Basmak", "Sukkur"],
+        "culture": "sindhi"
+    },
+    "Medantaka": {
+        "settlements": ["Medantaka", "Sanjoo", "Purnatallakapura", "Phalarddhi"],
+        "culture": "rajput"
+    },
+    "Kundina": {
+        "settlements": ["Prithiminagar", "Tinsukia", "Kundina", "Sadiya"],
+        "culture": "assamese"
+    },
+    "Karur": {
+        "settlements": ["Karur", "Askhanda", "Marot", "Chishtian", "Vehari"],
+        "culture": "panjabi"
+    },
+    "Sakala": {
+        "settlements": ["Bhuttar", "Jammu", "Puran Nagar", "Sakala", "Pasrur", "Vallapura", "Bahu"],
+        "culture": "panjabi"
+    },
+    "Trier": {
+        "settlements": ["Trier", "Sponheim", "Coblenz", "Wittlich", "Gerolstein", "Laach", "Bitburg", "Andernach"],
+        "culture": "old_frankish"
+    },
+    "Udabhanda": {
+        "settlements": ["Charsada", "Ohind", "Mankiala", "Attak", "Rawal", "Udabhanda"],
+        "culture": "panjabi"
+    },
+    "Oshrusana": {
+        "settlements": ["Khujand", "Oshrusana", "Banjikat"],
+        "culture": "sogdian"
+    },
+    "Ghazna": {
+        "settlements": ["Ghazna", "Khost", "Gardez"],
+        "culture": "afghan"
+    },
+    "Bost": {
+        "settlements": ["Kandahar", "Sangin"],
+        "culture": "afghan"
+    },
+    "Kalat": {
+        "settlements": ["Kalat"],
+        "culture": "afghan"
+    },
+    "Kabul": {
+        "settlements": ["Kabul", "Kapisa", "Kunar", "Kharabat", "Adinapur", "Lampara", "Nagarahara"],
+        "culture": "afghan"
+    },
+    "Chach": {
+        "settlements": ["Turbat", "Pskent", "Sayram", "Isbijab", "Navekat", "Shymkent", "Chach"],
+        "culture": "sogdian"
+    },
+    "Kunduz": {
+        "settlements": ["Surkh Kotal", "Aibak"],
+        "culture": "persian"
+    },
+    "Khuttal": {
+        "settlements": ["Munk", "Rasht", "Vakash", "Halaward", "Qobadhiyan", "Washjird", "Kulob"],
+        "culture": "sogdian"
+    },
+    "Bamiyan": {
+        "settlements": ["Istalif", "Zakhak", "Chak", "Shar I Gholghola", "Shibar", "Bamiyan"],
+        "culture": "afghan"
+    },
+    "Koln": {
+        "settlements": ["Koln", "Berg", "Mark", "Bonn", "Saffenburg", "Hochstaden", "Brauweiler", "Dietz"],
+        "culture": "german"
+    },
+    "Gurjaratra": {
+        "settlements": ["Jhelum", "Hakla", "Tibbi", "Gurjaratra", "Kunjah", "Bhaddar", "Karianwala", "Kharian"],
+        "culture": "panjabi"
+    },
+    "Bannu": {
+        "settlements": ["Hangu", "Karrak", "Kalabagh", "Dinkot", "Kohat", "Bannu"],
+        "culture": "panjabi"
+    },
+    "Bhera": {
+        "settlements": ["Bhera", "Rampur", "Phalia", "Girjakh", "Katasraj", "Behak Maken"],
+        "culture": "panjabi"
+    },
+    "Trigarta": {
+        "settlements": ["Jalandhar", "Kaparthula", "Rahon", "Milwat", "Pathankot", "Sarwmanpur"],
+        "culture": "panjabi"
+    },
+    "Nagadipa": {
+        "settlements": ["Yapapatuna", "Vallipuram", "Nainativu", "Nallur", "Sukaratittha"],
+        "culture": "tamil"
+    },
+    "Phiti": {
+        "settlements": ["Anuradhapura", "Mihintale", "Atamasthana", "Mannara", "Mahatittha", "Subhagiri", "Punkhagama"],
+        "culture": "sinhala"
+    },
+    "Srirangapatna": {
+        "settlements": ["Belapura", "Panasoge", "Periyapatna", "Srirangapatna", "Mysore", "Nanjarayapattana"],
+        "culture": "kannada"
+    },
+    "Dwarasamudra": {
+        "settlements": ["Koravangala", "Hassan", "Dwarasamudra", "Arasikere", "Sosavur", "Javagallu", "Belur"],
+        "culture": "kannada"
+    },
+    "Vatapi": {
+        "settlements": ["Vatapi", "Dharwar", "Venugrama", "Bagalkot", "Halasi", "Parasgad", "Aihole"],
+        "culture": "kannada"
+    },
+    "Penugonda": {
+        "settlements": ["Togarakunta", "Penugonda", "Lepakshi", "Uravakonda", "Suragiri", "Anantapur", "Gurramkonda", "Rayadurgam"],
+        "culture": "kannada"
+    },
+    "Ossory": {
+        "settlements": ["Callan", "Aghaboe", "Grennan", "Gowran", "Clonmacnoise", "Jerpoint", "Grannagh", "Kilkenny"],
+        "culture": "irish"
+    },
+    "Gottingen": {
+        "settlements": ["Corvey", "Northeim", "Lippe", "Detmold", "Gottingen", "Eisenach", "Kassel"],
+        "culture": "old_saxon"
+    },
+    "Kanara": {
+        "settlements": ["Udayavara", "Dharmasthala", "Udupi", "Mangalur", "Kadarika", "Kasargod"],
+        "culture": "kannada"
+    },
+    "Kongu": {
+        "settlements": ["Tiruppur", "Perur", "Karavur", "Namakkal", "Erode", "Dharapuri", "Sankagiri", "Hemambika", "Sendamangalam"],
+        "culture": "tamil"
+    },
+    "Kudalasangama": {
+        "settlements": ["Kuknur", "Anegundi", "Bagali", "Dambal", "Kudalasangama", "Koppam", "Musangi"],
+        "culture": "kannada"
+    },
+    "Idatarainadu": {
+        "settlements": ["Gabburu", "Hemagudda", "Manvi", "Mudgal", "Kammatadurga", "Raichur", "Jaladurga"],
+        "culture": "kannada"
+    },
+    "Nellore": {
+        "settlements": ["Mutapali", "Tripurantakam", "Nellore", "Kandukura", "Kalahasti", "Gundigapuri", "Addanki"],
+        "culture": "telugu"
+    },
+    "Narim": {
+        "settlements": ["Kolta"],
+        "culture": "khanty"
+    },
+    "Taradavadi": {
+        "settlements": ["Pandharpur", "Taradavadi", "Sangole", "Saundatti", "Viyapura", "Hastikundi"],
+        "culture": "kannada"
+    },
+    "Amaravati": {
+        "settlements": ["Gurazala", "Amaravati", "Dhanyakataka", "Ahobalam", "Macherla", "Kotappakonda", "Vinukonda"],
+        "culture": "telugu"
+    },
+    "Kambampet": {
+        "settlements": ["Penuballi", "Nelakondapalli", "Kambampet", "Shahpura", "Bhadrachalam", "Madupalli", "Suryapet"],
+        "culture": "telugu"
+    },
+    "Racakonda": {
+        "settlements": ["Bhuvanagiri", "Yadagirigutta", "Manchal", "Racakonda"],
+        "culture": "telugu"
+    },
+    "Nassau": {
+        "settlements": ["Katzenelnbogen", "Nassau", "Wetzlar", "Hersfeld", "Falkenstein", "Fulda", "Isenburg", "Marburg"],
+        "culture": "german"
+    },
+    "Manyakheta": {
+        "settlements": ["Yadavagiri", "Kovilkonda", "Sedam", "Firuzabad", "Manyakheta", "Gulbarga"],
+        "culture": "kannada"
+    },
+    "Pannagallu": {
+        "settlements": ["Ghanpur", "Nagarkurnool", "Mutudugu", "Pannagallu", "Charakonda"],
+        "culture": "telugu"
+    },
+    "Lattalura": {
+        "settlements": ["Bir", "Barshi", "Udgir", "Darur", "Tagara", "Lattalura"],
+        "culture": "marathi"
+    },
+    "Kondana": {
+        "settlements": ["Bhimashankara", "Raigad", "Purandar", "Puna", "Tikona", "Junir", "Rajmachi", "Sudhagad", "Kondana", "Chakan"],
+        "culture": "marathi"
+    },
+    "Tirunelveli": {
+        "settlements": ["Tirunelveli", "Korkai", "Kalugumalai", "Tiruvalisvaram", "Kayattar", "Kayal"],
+        "culture": "tamil"
+    },
+    "Dakhina Desa": {
+        "settlements": ["Rayigama", "Jambudoni", "Kalyani2", "Hatthigiripura", "Kotte", "Vapinagara", "Mahiyangana", "Samantakuta"],
+        "culture": "sinhala"
+    },
+    "Talakad": {
+        "settlements": ["Talakad", "Ummattur", "Veppur", "Nanjangud", "Somanathapura", "Narasamangala", "Kotagiri", "Sivasamudram"],
+        "culture": "kannada"
+    },
+    "Nandagiri": {
+        "settlements": ["Nandagiri", "Kurudumale", "Avani", "Kuvalala", "Kundani", "Mulavagil", "Nangali"],
+        "culture": "kannada"
+    },
+    "Alampur": {
+        "settlements": ["Kampili", "Ittagi", "Vijayanagara", "Gooty", "Hampi", "Adavani", "Alampur"],
+        "culture": "kannada"
+    },
+    "Potapi": {
+        "settlements": ["Potapi", "Melpadi", "Tirupati", "Virincipuram", "Kalahasti", "Kaveripattinam"],
+        "culture": "telugu"
+    },
+    "Leiningen": {
+        "settlements": ["Lorsch", "Hardenburg", "Durkheim", "Leiningen", "Battenberg", "Ungstein", "Pfeffingen", "Heidelberg"],
+        "culture": "german"
+    },
+    "Goa": {
+        "settlements": ["Kapardikadvipa", "Chitrakul", "Gopakapattana", "Gheria", "Mathagram", "Chandrapur"],
+        "culture": "marathi"
+    },
+    "Vijayawada": {
+        "settlements": ["Guntur", "Vijayawada", "Peddapalli", "Masula", "Kondavidu", "Chebrolu"],
+        "culture": "telugu"
+    },
+    "Rajamahendravaram": {
+        "settlements": ["Barsoor", "Dantewada", "Rajamahendravaram", "Kirandul", "Kuwakonda", "Bhadrachalam"],
+        "culture": "telugu"
+    },
+    "Ishim": {
+        "settlements": ["Esil"],
+        "culture": "cuman"
+    },
+    "Kalinganagar": {
+        "settlements": ["Mandasa", "Kalingapattanam", "Kalinganagara", "Srikakulam", "Srikurmam"],
+        "culture": "oriya"
+    },
+    "Puri": {
+        "settlements": ["Ganjam", "Puri", "Jaugada", "Buguda", "Aska", "Gopalpur", "Taratarini"],
+        "culture": "oriya"
+    },
+    "Nandapur": {
+        "settlements": ["Nandapur", "Jeypore", "Junagarh", "Koraput", "Dharamgarh"],
+        "culture": "oriya"
+    },
+    "Cakrakuta": {
+        "settlements": ["Kanker", "Jagdalpur", "Cakrakuta"],
+        "culture": "oriya"
+    },
+    "Swetaka Mandala": {
+        "settlements": ["Umerkote", "Swetakapura", "Badakhemundi", "Rayagada"],
+        "culture": "oriya"
+    },
+    "Khinjali Mandala": {
+        "settlements": ["Khinjali", "Nilamadhav", "Nayagarh", "Baramba"],
+        "culture": "oriya"
+    },
+    "Mainz": {
+        "settlements": ["Weilburg", "Ingelheim", "Mainz", "Dornburg", "Mannheim", "Frankfurt", "Eppstein", "Hanau"],
+        "culture": "old_frankish"
+    },
+    "Suvarnapura": {
+        "settlements": ["Agalpur", "Suvarnapura", "Yajatinagara", "Bargarh", "Patna", "Vinitapura", "Kalahandi"],
+        "culture": "oriya"
+    },
+    "Viraja": {
+        "settlements": ["Bhadrak", "Viraja", "Soro", "Raibania", "Anandpur", "Baleshvara", "Mahavinayak"],
+        "culture": "oriya"
+    },
+    "Midnapore": {
+        "settlements": ["Dantan", "Hilji", "Moghalmari", "Kashipur", "Midnapore"],
+        "culture": "oriya"
+    },
+    "Saptagrama": {
+        "settlements": ["Bansberia", "Pandua", "Tribeni", "Shantipur", "Saptagrama", "Mahanad", "Chinsura"],
+        "culture": "bengali"
+    },
+    "Damin I Koh": {
+        "settlements": ["Deogarh2", "Shikarji"],
+        "culture": "bengali"
+    },
+    "Tamralipti": {
+        "settlements": ["Sagardwip", "Chandraketugarh", "Jahajghata", "Tamralipti", "Ishwaripur"],
+        "culture": "bengali"
+    },
+    "Candradvipa": {
+        "settlements": ["Sathkira", "Bagerhat", "Khulna", "Bakarganj", "Candradvipa"],
+        "culture": "bengali"
+    },
+    "Rajrappa": {
+        "settlements": ["Kenduli"],
+        "culture": "bengali"
+    },
+    "Mallabhum": {
+        "settlements": ["Garhbeta", "Baghmundi", "Bishnupur", "Chandrakona", "Dihar", "Mandaran"],
+        "culture": "bengali"
+    },
+    "Vijayapura": {
+        "settlements": ["Patuli", "Dishergarh", "Churulia", "Kalna", "Begunia", "Vijayapura"],
+        "culture": "bengali"
+    },
+    "Pfalz": {
+        "settlements": ["Kaiserslautern", "Trifels", "Stahleck", "Worms", "Hagenau", "Zweibrucken", "Saarbrucken", "Speyer"],
+        "culture": "german"
+    },
+    "Kumara Mandala": {
+        "settlements": ["Fathabad", "Kumarakhali", "Ekdala", "Katasgarh"],
+        "culture": "bengali"
+    },
+    "Jharkand": {
+        "settlements": ["Kandra", "Ambikapur", "Koriya"],
+        "culture": "bengali"
+    },
+    "Radha": {
+        "settlements": ["Lakhnor", "Ichhai Ghoshgarh", "Rampur Boalia", "Gopbhum", "Kalyaneshwari", "Katwa", "Hirapur"],
+        "culture": "bengali"
+    },
+    "Gauda": {
+        "settlements": ["Raktamrittika", "Agmahl", "Adinatha Mandir", "Karnasubarna", "Tarapith", "Teliagarhi"],
+        "culture": "bengali"
+    },
+    "Kamatapur": {
+        "settlements": ["Bhitagarh", "Nalrajar Garh", "Japyesvara", "Kamatapur", "Mainaguri"],
+        "culture": "assamese"
+    },
+    "Srihatta": {
+        "settlements": ["Habiganj", "Egarosindur", "Jangalbari", "Srihatta", "Nasirabad"],
+        "culture": "assamese"
+    },
+    "Goalpara": {
+        "settlements": ["Kamakhya", "Dhubri", "Sri Surya Pahar", "Goalpara"],
+        "culture": "assamese"
+    },
+    "Khijjingakota": {
+        "settlements": ["Bahalda", "Asanapat", "Baripada", "Kirianagar", "Sitabhinji", "Khijjinga", "Ghatagaon"],
+        "culture": "oriya"
+    },
+    "Munda": {
+        "settlements": ["Marang Buru", "Chutia", "Ratu"],
+        "culture": "oriya"
+    },
+    "Sambalpur": {
+        "settlements": ["Rajgangpur", "Bimaleswar", "Sambalpur", "Maneswar", "Ranipur", "Samaleswari"],
+        "culture": "oriya"
+    },
+    "Baden": {
+        "settlements": ["Karlsruhe", "Pforzheim", "Rastatt", "Neuhausen", "Baden", "Durlach", "Calw", "Wimpfen"],
+        "culture": "german"
+    },
+    "Ayodhya": {
+        "settlements": ["Ayodhya", "Nageshwarnath", "Faizabad", "Hanuman Garhi", "Ramkot", "Sarairasi"],
+        "culture": "hindustani"
+    },
+    "Sasaram": {
+        "settlements": ["Mundeshwari", "Jaund", "Horilnagar", "Arrah", "Sasaram"],
+        "culture": "bengali"
+    },
+    "Barasuru": {
+        "settlements": ["Dantewada", "Barasuru", "Barsoor"],
+        "culture": "oriya"
+    },
+    "Nilagiri": {
+        "settlements": ["Panagallu", "Maheshwaram", "Vadapally", "Avulagadda", "Devarakonda", "Nilagiri"],
+        "culture": "telugu"
+    },
+    "Vairagara": {
+        "settlements": ["Bhandugara", "Cikamburika", "Vairagara", "Gondia"],
+        "culture": "marathi"
+    },
+    "Vemulavada": {
+        "settlements": ["Kaleshwaram", "Indur", "Vemulavada", "Kaulas", "Ramgarh", "Potali"],
+        "culture": "telugu"
+    },
+    "Orangallu": {
+        "settlements": ["Ghanpur", "Warangal", "Anumakonda", "Kothakonda", "Bhadrakali", "Palampet", "Molangoor"],
+        "culture": "telugu"
+    },
+    "Medak": {
+        "settlements": ["Domakonda", "Kohir", "Medak", "Ananthagiri", "Mardi"],
+        "culture": "telugu"
+    },
+    "Nanded": {
+        "settlements": ["Nanded", "Shelgaon", "Pathri", "Qandhar", "Aurad", "Parbhani"],
+        "culture": "marathi"
+    },
+    "Vatsagulma": {
+        "settlements": ["Lonar", "Satgaon", "Vatsagulma", "Jalna", "Manora", "Nandura"],
+        "culture": "marathi"
+    },
+    "Nordgau": {
+        "settlements": ["Strassburg", "Egisheim", "Erstein", "Brumath", "Molsheim", "Lauterburg", "Schlettstadt", "Selz"],
+        "culture": "old_frankish"
+    },
+    "Nasikya": {
+        "settlements": ["Seunapura", "Ratangad", "Saptashrungi", "Patta", "Nasikya", "Igatpuri", "Tryambaka"],
+        "culture": "marathi"
+    },
+    "Parnakheta": {
+        "settlements": ["Parnakheta", "Karanja", "Buldhana", "Ambadapura", "Mahkar", "Akola"],
+        "culture": "marathi"
+    },
+    "Thalner": {
+        "settlements": ["Thalner", "Bhamer", "Laling", "Jhodga", "Amalner", "Balasane", "Sindkheda"],
+        "culture": "marathi"
+    },
+    "Burhanpur": {
+        "settlements": ["Yawal", "Vaghli", "Burhanpur", "Erandol", "Changdev"],
+        "culture": "marathi"
+    },
+    "Nandurbar": {
+        "settlements": ["Songarh", "Nandurbar", "Malegaon", "Mayuragiri", "Sultanpur", "Bhambhagiri", "Chandor"],
+        "culture": "marathi"
+    },
+    "Sagar": {
+        "settlements": ["Pattadakal", "Bagavadi", "Talikota", "Sagar", "Bagalkot", "Sorapur"],
+        "culture": "kannada"
+    },
+    "Somnath": {
+        "settlements": ["Diu", "Delvada", "Veraval", "Vejalkot", "Moherak", "Somnath", "Kanjetar"],
+        "culture": "gujurati"
+    },
+    "Vardhamana": {
+        "settlements": ["Ranpur", "Halvad", "Amarvalli", "Vardhamana"],
+        "culture": "gujurati"
+    },
+    "Dhamalpur": {
+        "settlements": ["Lakhota", "Halvad", "Dhamalpur", "Khasta", "Morvi"],
+        "culture": "gujurati"
+    },
+    "Canda": {
+        "settlements": ["Canda", "Nagbhid", "Ballarpur", "Rajura", "Gadchiroli"],
+        "culture": "telugu"
+    },
+    "Lorraine": {
+        "settlements": ["Charpeigne", "Mortagnedevosges", "Epinal", "Luneville", "Sarrebourg", "Toul", "Nancy", "Saintavoid"],
+        "culture": "old_frankish"
+    },
+    "Kiranapura": {
+        "settlements": ["Lanji", "Kiranapura", "Balaghat"],
+        "culture": "marathi"
+    },
+    "Tripuri": {
+        "settlements": ["Garha", "Tripuri", "Mandla"],
+        "culture": "hindustani"
+    },
+    "Ratanpur": {
+        "settlements": ["Ratanpur", "Saravpur", "Pali", "Savarinarayana"],
+        "culture": "hindustani"
+    },
+    "Turgay": {
+        "settlements": ["Zhailyk", "Karakal"],
+        "culture": "pecheneg"
+    },
+    "Damoh": {
+        "settlements": ["Nohta", "Dhamoni", "Singrampur", "Narsinghgarh", "Damoh"],
+        "culture": "hindustani"
+    },
+    "Zaranj": {
+        "settlements": ["Zaranj", "Zahak", "Zabol"],
+        "culture": "afghan"
+    },
+    "Gaya": {
+        "settlements": ["Nawada", "Bodh Gaya", "Sherghati", "Elahabad", "Nalanda"],
+        "culture": "bengali"
+    },
+    "Tummana": {
+        "settlements": ["Amarkantak", "Manendragarh", "Tummana"],
+        "culture": "hindustani"
+    },
+    "Gurgi": {
+        "settlements": ["Satna", "Gurgi", "Chandrehi", "Bathgahora"],
+        "culture": "hindustani"
+    },
+    "Rohana": {
+        "settlements": ["Devanagara", "Mahagama", "Dighavapi", "Kajaragama", "Buduruvagala", "Gampala", "Mahanagakula"],
+        "culture": "sinhala"
+    },
+    "Metz": {
+        "settlements": ["Bouzonville", "Joudreville", "Thionville", "Metz", "Saintjulien", "Marslatour", "Audunleroman", "Briey"],
+        "culture": "old_frankish"
+    },
+    "Gojjam": {
+        "settlements": ["Gojjam", "Mankorar", "Yejube", "Godana Mikael", "Yegeleka", "Baremma", "Eliyas"],
+        "culture": "ethiopian"
+    },
+    "Chunar": {
+        "settlements": ["Chunar", "Vindhyachal", "Kantit"],
+        "culture": "hindustani"
+    },
+    "Dotawo": {
+        "settlements": ["Premnis", "Faras", "Jebeladda", "Buhen", "Ballana", "Qasribrim", "Dotawo"],
+        "culture": "nubian"
+    },
+    "Asni": {
+        "settlements": ["Bhitargaon", "Asni2", "Bindki", "Kora", "Shivrajpur", "Musanagar", "Khaga"],
+        "culture": "hindustani"
+    },
+    "Bharauli": {
+        "settlements": ["Manikpur", "Lalganj", "Bhadri", "Bharauli"],
+        "culture": "hindustani"
+    },
+    "Acalapura": {
+        "settlements": ["Yavatmal", "Bhojapur", "Narnala", "Acalapura", "Kalam", "Amravati"],
+        "culture": "marathi"
+    },
+    "Kherla": {
+        "settlements": ["Pachmarhi", "Anjangaon", "Kherla", "Gawilghar"],
+        "culture": "marathi"
+    },
+    "Asirgarh": {
+        "settlements": ["Sanawad", "Mandleshwar", "Khargone", "Asirgarh", "Khandwa"],
+        "culture": "marathi"
+    },
+    "Ujjayini": {
+        "settlements": ["Ujjayini", "Mehidpur", "Akodia", "Maksi", "Dewas", "Agar"],
+        "culture": "hindustani"
+    },
+    "Dadhipadra": {
+        "settlements": ["Jawad", "Godhra", "Dadhipadra", "Pavagadh", "Champaner", "Kalika Mata"],
+        "culture": "rajput"
+    },
+    "Verdun": {
+        "settlements": [],
+        "culture": "old_frankish"
+    },
+    "Khetaka": {
+        "settlements": ["Bhadran", "Khambhat", "Khetaka", "Tarapur", "Ashaval", "Dholka", "Sanand", "Nadiad"],
+        "culture": "gujurati"
+    },
+    "Mohadavasaka": {
+        "settlements": ["Shamlaji", "Lunawada", "Unjha", "Danta", "Jhalod", "Mohadavasaka"],
+        "culture": "rajput"
+    },
+    "Sarasvata Mandala": {
+        "settlements": ["Shertha", "Kamboika", "Kheralu", "Idar", "Siddhapura", "Anahilapataka", "Modhera"],
+        "culture": "gujurati"
+    },
+    "Satyapura": {
+        "settlements": ["Kiradu", "Juna Barmer", "Kiratakupa", "Satyapura"],
+        "culture": "rajput"
+    },
+    "Kutch": {
+        "settlements": ["Bhuj", "Kanthakota", "Dhaneti", "Anjar"],
+        "culture": "gujurati"
+    },
+    "Dimapur": {
+        "settlements": ["Oddiyana", "Herombial", "Dimapur", "Maibong"],
+        "culture": "assamese"
+    },
+    "Debul": {
+        "settlements": ["Banbhore", "Kolachi", "Debul", "Shahbandar", "Lari Bandar", "Thatta", "Makli", "Landhi"],
+        "culture": "sindhi"
+    },
+    "Chanderi": {
+        "settlements": ["Chanderi", "Garh Kundar", "Jarai Ka Math", "Aharji", "Khurai", "Jhansi", "Luacchagiri"],
+        "culture": "hindustani"
+    },
+    "Candhoba": {
+        "settlements": ["Candhoba", "Sipri", "Guna", "Kadwaya"],
+        "culture": "hindustani"
+    },
+    "Thomond": {
+        "settlements": ["Ennis", "Killaloe", "Kilfenora", "Limerick", "Adare", "Bunratty", "Askeaton", "Emly"],
+        "culture": "irish"
+    },
+    "Troyes": {
+        "settlements": ["Clairvaux", "Troyes", "Brienne", "Chacenay", "Chaumont", "Langres"],
+        "culture": "old_frankish"
+    },
+    "Kota": {
+        "settlements": ["Taragarh", "Kota", "Ramgarh", "Bundi", "Koshvardhan"],
+        "culture": "rajput"
+    },
+    "Mahoba": {
+        "settlements": ["Chitrakuta", "Mahoba", "Ajaigarh", "Rath", "Hamirpur"],
+        "culture": "hindustani"
+    },
+    "Chitrakut": {
+        "settlements": ["Baroli", "Nagari", "Mandalgarh", "Rampura", "Bhainsrorgarh", "Chitrakut"],
+        "culture": "rajput"
+    },
+    "Ranikot": {
+        "settlements": ["Ranikot", "Sharusan", "Khudabad", "Jandar", "Paat", "Manhabari"],
+        "culture": "sindhi"
+    },
+    "Ludrava": {
+        "settlements": ["Lanela", "Pali", "Ludrava", "Jaisalmer", "Phalavardhika"],
+        "culture": "rajput"
+    },
+    "Tura": {
+        "settlements": ["Almaty"],
+        "culture": "kirghiz"
+    },
+    "Sens": {
+        "settlements": ["Montereau", "Villeneuveleroi", "Nogentsurseine", "Montargis", "Chateaulandon", "Joigny", "Sens", "Nemours"],
+        "culture": "old_frankish"
+    },
+    "Samatata": {
+        "settlements": ["Chatigama", "Candranatha", "Devaparvata"],
+        "culture": "bengali"
+    },
+    "Bikrampur": {
+        "settlements": ["Sutrapur", "Loricol", "Hajiganj", "Bikrampur", "Shakhari Bazar", "Dhakeshwari Jatiya Mandir"],
+        "culture": "bengali"
+    },
+    "Auxerre": {
+        "settlements": ["Pontigny", "Druyes", "Crisenon", "Tonnerre", "Cravant", "Mailly", "Auxerre", "Stsauveurenpuisaye"],
+        "culture": "old_frankish"
+    },
+    "Aydhab": {
+        "settlements": ["Aydhab", "Troglodytica", "Zabargad", "Halayeb", "Elba", "Marsaalam", "Shalateen"],
+        "culture": "nubian"
+    },
+    "Kamarupanagara": {
+        "settlements": ["Pragyotisapura", "Kamarupanagara", "Hajo", "Dariyaon", "Madan Kamdev", "Manikuta", "Durjaya"],
+        "culture": "assamese"
+    },
+    "Nobatia": {
+        "settlements": ["Abri", "Akasha", "Nubia", "Soleb", "Delgo", "Semna", "Wawa"],
+        "culture": "nubian"
+    },
+    "Nabadwipa": {
+        "settlements": ["Nabadwipa", "Bidhyanandikathi", "Pancharatna", "Krishnagar", "Madhyadwip", "Godrumdwip", "Ritudwip"],
+        "culture": "bengali"
+    },
+    "Suvarnagram": {
+        "settlements": ["Satkhira", "Suvarnagram", "Narikella", "Bokainagar", "Susanga"],
+        "culture": "assamese"
+    },
+    "Madhupur": {
+        "settlements": ["Pabna", "Madhupur", "Bogra", "Baghabarihat"],
+        "culture": "bengali"
+    },
+    "Napata": {
+        "settlements": ["Keheilli", "Karima", "Marawi", "Napata", "Kanisah", "Korti"],
+        "culture": "nubian"
+    },
+    "Rothas": {
+        "settlements": ["Rohtas", "Palamau", "Rohtasan", "Rohtasgarh", "Betla"],
+        "culture": "bengali"
+    },
+    "Prayaga": {
+        "settlements": ["Prayaga", "Daraganj", "Chowk", "Alopibagh", "Kausambi", "Kara", "Dariyabad"],
+        "culture": "hindustani"
+    },
+    "Ket": {
+        "settlements": ["Sochur"],
+        "culture": "kirghiz"
+    },
+    "Saintois": {
+        "settlements": ["Saintois", "Ornois", "Dompaire", "Saulnois", "Brixey", "Ivios", "Vaudemont", "Sorcystmartin"],
+        "culture": "old_frankish"
+    },
+    "Suakin": {
+        "settlements": ["Derkin", "Salum", "Komelshokafa", "Tisiamti", "Dubarua", "Taiwi", "Sawakin"],
+        "culture": "nubian"
+    },
+    "Sonda": {
+        "settlements": ["Karoonjar", "Amarkot", "Matli", "Mamhal", "Sonda", "Nagarparkar", "Badin"],
+        "culture": "sindhi"
+    },
+    "Trinkitat": {
+        "settlements": ["Derri", "Trinkitat", "Teb", "Mukden", "Kwababa", "Tokar", "Farata"],
+        "culture": "nubian"
+    },
+    "Siwistan": {
+        "settlements": ["Siwistan", "Vicalapura", "Guja", "Mir Rukan", "Dahlilah"],
+        "culture": "sindhi"
+    },
+    "Alodia": {
+        "settlements": ["Malaka", "Omdurman", "Omjerky", "Wawissi", "Barah", "Alwa"],
+        "culture": "nubian"
+    },
+    "Kosti": {
+        "settlements": ["Lagawa", "Umm Ruwaba", "Dalang", "Kosti", "Kaduqli", "Abbeit"],
+        "culture": "nubian"
+    },
+    "Vijnot": {
+        "settlements": ["Kishangarh", "Vijnot", "Ghotki", "Bhatiya"],
+        "culture": "sindhi"
+    },
+    "Uch": {
+        "settlements": ["Chachran", "Chaudari", "Sitpur", "Derawar", "Mithankot", "Uch"],
+        "culture": "panjabi"
+    },
+    "Multan": {
+        "settlements": ["Mulasthana", "Prahladpuri", "Makhdum Rashid", "Alipur", "Multan", "Kabirwala", "Tulamba"],
+        "culture": "panjabi"
+    },
+    "Rajanpur": {
+        "settlements": ["Harrand", "Rojhan", "Dajal", "Rajanpur", "Adhiwala"],
+        "culture": "sindhi"
+    },
+    "Sundgau": {
+        "settlements": ["Landser", "Ferette", "Mulhouse", "Altkirch", "Ensisheim", "Thann", "Murbach", "Kolmar"],
+        "culture": "old_frankish"
+    },
+    "Karor": {
+        "settlements": ["Shadia", "Mankera", "Karor", "Wan Bhachran"],
+        "culture": "panjabi"
+    },
+    "Nandana": {
+        "settlements": ["Simhapura", "Tulaja", "Khushab", "Khewra", "Nandana", "Hund", "Lund2"],
+        "culture": "panjabi"
+    },
+    "Purushapura": {
+        "settlements": ["Purushapura", "Mardan", "Bajaur", "Nowshera", "Shergarh", "Shah Ji Dheri", "Ali Masjid"],
+        "culture": "panjabi"
+    },
+    "Massawa": {
+        "settlements": ["Cheren", "Dahano", "Matara", "Adulis", "Massawa", "Sembel", "Qohaito"],
+        "culture": "nubian"
+    },
+    "Zeila": {
+        "settlements": ["Zeila", "Amud", "Hargeysa", "Lughaya", "Dilla", "Jijiga", "Borama"],
+        "culture": "somali"
+    },
+    "Medapata": {
+        "settlements": ["Aghata", "Nagahrada", "Sas Bahu", "Rishabhdeo", "Eklingji", "Bagar", "Jagadamba"],
+        "culture": "rajput"
+    },
+    "Ajayameru": {
+        "settlements": ["Dhanop", "Pushkar", "Lawah", "Taragarh", "Shakambhari", "Nareli", "Ajayameru"],
+        "culture": "rajput"
+    },
+    "Vikramapura": {
+        "settlements": ["Vikramapura", "Kolayat", "Shekhsar", "Bhurupal", "Bhandasar"],
+        "culture": "rajput"
+    },
+    "Besancon": {
+        "settlements": ["Beaucourt", "Vesoul", "Montbeliard", "Besancon", "Valdahon", "Morteau", "Belfort", "Maiche"],
+        "culture": "old_frankish"
+    },
+    "Reni": {
+        "settlements": ["Mandir", "Reni", "Bidasar", "Dadrewa", "Sidhmukh"],
+        "culture": "rajput"
+    },
+    "Nagchu": {
+        "settlements": ["Nagchu"],
+        "culture": "sumpa"
+    },
+    "Sarasvati": {
+        "settlements": ["Bhatnir", "Bhadra", "Tarain", "Sarasvati"],
+        "culture": "hindustani"
+    },
+    "Vairata": {
+        "settlements": ["Amer", "Dhosi", "Jeenmata", "Harshnath", "Khatushyam", "Vairata", "Sanganer"],
+        "culture": "rajput"
+    },
+    "Nagauda": {
+        "settlements": ["Nagauda", "Ladnun", "Kuchaman", "Mundwa", "Ladnu", "Ahichhatrapur", "Makrana"],
+        "culture": "rajput"
+    },
+    "Ranthambore": {
+        "settlements": ["Gangapur", "Sheopur", "Tonkra", "Mandrael", "Utgir", "Ranthambore"],
+        "culture": "rajput"
+    },
+    "Kanyakubja": {
+        "settlements": ["Kampil", "Bithor", "Swargdwari", "Jai Chandra", "Etawah", "Kanyakubja", "Jajmau"],
+        "culture": "hindustani"
+    },
+    "Sripatha": {
+        "settlements": ["Sripatha", "Abanhagari", "Dhavalapuri", "Dholeshwar Mahadev", "Bayana"],
+        "culture": "hindustani"
+    },
+    "Vodamayutja": {
+        "settlements": ["Vodamayutja", "Tilokpur", "Bareily", "Sheikhupur", "Anwala", "Ahichatra"],
+        "culture": "hindustani"
+    },
+    "Mathura": {
+        "settlements": ["Agra", "Govardhan", "Mankameshwar", "Dhanauli", "Mathura", "Vrindavan", "Khanwa"],
+        "culture": "hindustani"
+    },
+    "Dijon": {
+        "settlements": ["Beaune", "Vezelay", "Citeaux", "Dijon", "Avallon", "Autun", "Noyers", "Semur"],
+        "culture": "old_frankish"
+    },
+    "Maldives": {
+        "settlements": ["Dhanbidhoo", "Gan", "Mundoo", "Mahal", "Isdhoo", "Salliballu", "Fuvahmulah"],
+        "culture": "tamil"
+    },
+    "Shorkot": {
+        "settlements": ["Bhirr", "Chandrod", "Shorkot", "Kamalia", "Jhang", "Rabwah", "Bhawana"],
+        "culture": "panjabi"
+    },
+    "Lahur": {
+        "settlements": ["Lahur", "Mehdiabad", "Chunian", "Kasur", "Samnabad", "Data Darbar", "Sangla"],
+        "culture": "panjabi"
+    },
+    "Dipalpur": {
+        "settlements": ["Dipalpur", "Abohar", "Satghara", "Chichawatni", "Ajodhan", "Pancapura"],
+        "culture": "panjabi"
+    },
+    "Tribandapura": {
+        "settlements": ["Jaintpuri", "Kartikeya", "Tribandapura", "Sunam", "Amin"],
+        "culture": "hindustani"
+    },
+    "Delhi": {
+        "settlements": ["Lalkot", "Mehrauli", "Siri", "Jahanpanah", "Dhilika", "Narela", "Indraprastha"],
+        "culture": "hindustani"
+    },
+    "Hisar": {
+        "settlements": ["Kalanaur", "Agroha", "Asika", "Asigarh", "Surajkund", "Hisar", "Rohtak"],
+        "culture": "hindustani"
+    },
+    "Sthanisvara": {
+        "settlements": ["Karnal", "Sthanisvara", "Samana", "Shakumbhri Devi", "Panipat", "Saharanpur", "Sirhind"],
+        "culture": "hindustani"
+    },
+    "Hastinapura": {
+        "settlements": ["Hastinapura", "Pankot", "Baran", "Pandeshwar", "Mirath", "Hapur", "Indrasthana"],
+        "culture": "hindustani"
+    },
+    "Socotra": {
+        "settlements": ["Siqirah", "Asma", "Tamrida", "Qualnsiyah", "Qashiu", "Qadub", "Steroh"],
+        "culture": "bedouin_arabic"
+    },
+    "Nevers": {
+        "settlements": ["Nevers", "Courtenay", "Donzy", "Lacharite", "Cosne", "Vandenesse", "Chateauchinon", "Clamecy"],
+        "culture": "old_frankish"
+    },
+    "Armail": {
+        "settlements": ["Yusli", "Kambali", "Armail", "Hingula"],
+        "culture": "sindhi"
+    },
+    "Quzdar": {
+        "settlements": ["Quzdar", "Bodein"],
+        "culture": "sindhi"
+    },
+    "Kandail": {
+        "settlements": ["Dadu", "Jhal", "Kandail"],
+        "culture": "sindhi"
+    },
+    "Assab": {
+        "settlements": ["Mergebla", "Debaysima", "Rehayto", "Gehare", "Assab", "Agurto", "Manda"],
+        "culture": "ethiopian"
+    },
+    "Sibi": {
+        "settlements": ["Walishtan", "Mastanj", "Dadhar", "Sibi"],
+        "culture": "sindhi"
+    },
+    "Kafirkot": {
+        "settlements": ["Malot", "Dera Ghazi Khan", "Maniot", "Bilot", "Kafirkot"],
+        "culture": "panjabi"
+    },
+    "Wana": {
+        "settlements": ["Bori"],
+        "culture": "afghan"
+    },
+    "Maymana": {
+        "settlements": ["Gurziwan", "Maymana", "Darzab", "Bilcheragh", "Almar"],
+        "culture": "persian"
+    },
+    "Urgench": {
+        "settlements": ["Urgench", "Kyrkmolla", "Kizil Agir"],
+        "culture": "persian"
+    },
+    "Asayita": {
+        "settlements": ["Serdo", "Asayita", "Lofefle", "Jewaha", "Afambo", "Tendaho", "Dedai"],
+        "culture": "ethiopian"
+    },
+    "Orleans": {
+        "settlements": ["Fleury", "Lepuiset", "Sully", "Gien", "Jargeau", "Meung", "Janville", "Orleans"],
+        "culture": "old_frankish"
+    },
+    "Semien": {
+        "settlements": ["Dabat", "Belesa", "Ambaras", "Ciarveta", "Amja Lebes", "Debark", "Oivela Mariam"],
+        "culture": "ethiopian"
+    },
+    "Pundravardhana": {
+        "settlements": ["Somapura Mahavihara", "Khulnar Dhap", "Bhimer Jangal", "Ghoraghat", "Totaram Panditer Dhap", "Pundravardhana", "Mahasthangarh"],
+        "culture": "bengali"
+    },
+    "Bourges": {
+        "settlements": ["Sancerre", "Deols", "Mehun", "Vierzon", "Chateauroux", "Bourges", "Stsatur", "Issoudun"],
+        "culture": "old_frankish"
+    },
+    "Desmond": {
+        "settlements": ["Cork", "Cloyne", "Ross", "Ardfert", "Youghal", "Dunasead", "Fermoy"],
+        "culture": "irish"
+    },
+    "Tourraine": {
+        "settlements": ["Loches", "Tours", "Chinon", "Beaulieu", "Langeais", "Montbazon", "Amboise", "Fierbois"],
+        "culture": "old_frankish"
+    },
+    "Anxi": {
+        "settlements": ["Anxi", "Guazhou"],
+        "culture": "han"
+    },
+    "Poitiers": {
+        "settlements": ["Loudun", "Poitiers", "Parthenay", "Chatellerault", "Stsavin", "Mirebeau", "Moncontour"],
+        "culture": "occitan"
+    },
+    "Venadu": {
+        "settlements": ["Anantasayanam", "Kollam", "Nagercoil", "Kandalur", "Vizhinjam", "Kanya Kumari"],
+        "culture": "tamil"
+    },
+    "Kotthasara": {
+        "settlements": ["Trincomalee", "Girikandaka", "Sigiriya", "Gokanna", "Vatagiri", "Pulatthinagara", "Madakalapuva"],
+        "culture": "sinhala"
+    },
+    "Pithapuram": {
+        "settlements": ["Samalkota", "Somarama", "Pithapuram", "Draksharama", "Kakinada", "Mandapeta"],
+        "culture": "telugu"
+    },
+    "Kolhapur": {
+        "settlements": ["Manapura", "Kolhapur", "Satara", "Miraj", "Pranala", "Karahataka", "Kurundaka"],
+        "culture": "marathi"
+    },
+    "Wag": {
+        "settlements": ["Lashwa", "Liktaba", "Sacca", "Zumbo", "Sekota", "Tsaicha", "Indeher Giba"],
+        "culture": "ethiopian"
+    },
+    "Haruppeswara": {
+        "settlements": ["Numaligarh", "Dibarumukh", "Haruppeswara", "Charaideo"],
+        "culture": "assamese"
+    },
+    "Mithila": {
+        "settlements": ["Darbhanga", "Hajipur", "Saligrama", "Yavamajjhaka", "Sugauna", "Mithila", "Siwan"],
+        "culture": "bengali"
+    },
+    "Thouars": {
+        "settlements": ["Fontenay", "Mauleon", "Larochelle", "Bressuire", "Chatelaillon", "Lucon", "Thouars", "Olonne"],
+        "culture": "old_frankish"
+    },
+    "Simaramapura": {
+        "settlements": ["Bettiah", "Kesaria", "Bhaktagrama", "Vaid", "Pattana", "Simaramapura"],
+        "culture": "bengali"
+    },
+    "Sravasti": {
+        "settlements": ["Barohiya", "Jetavana", "Sravasti", "Gorakhpur", "Maghar", "Gorakhnath Math", "Amorha"],
+        "culture": "hindustani"
+    },
+    "Naimisa": {
+        "settlements": ["Lakhimpur", "Sitapur", "Misrikh", "Gonda", "Naimisa", "Bahraich"],
+        "culture": "hindustani"
+    },
+    "Fergana": {
+        "settlements": ["Rishton", "Uzkand", "Marginan", "Aval", "Nadaq", "Osh", "Andijan"],
+        "culture": "sogdian"
+    },
+    "Chuy": {
+        "settlements": ["Almatu", "Bishkek"],
+        "culture": "karluk"
+    },
+    "Ili": {
+        "settlements": ["Koktal", "Kulja"],
+        "culture": "karluk"
+    },
+    "Zhetysu": {
+        "settlements": ["Taldykorgan", "Karatal"],
+        "culture": "karluk"
+    },
+    "Urzhar": {
+        "settlements": ["Ayagoz", "Akzhar"],
+        "culture": "kirghiz"
+    },
+    "Damot": {
+        "settlements": ["Yirga Chefe", "Muger", "Teltele", "Fasha", "Awasa", "Zima", "Malbarde"],
+        "culture": "ethiopian"
+    },
+    "Begemder": {
+        "settlements": ["Danya", "Maryamu", "Filakit", "Awariya", "Bete Yohanis", "Gereger", "Chekerefta"],
+        "culture": "ethiopian"
+    },
+    "Saintonge": {
+        "settlements": ["Tonnay", "Stjeandangely", "Villeneuve", "Taillebourg", "Saintes", "Montguyon", "Aulnay", "Royan"],
+        "culture": "occitan"
+    },
+    "Kipchak": {
+        "settlements": ["Kipchak", "Zhailma"],
+        "culture": "pecheneg"
+    },
+    "Otrar": {
+        "settlements": ["Shoshkakoi", "Shaulder"],
+        "culture": "karluk"
+    },
+    "Karluk": {
+        "settlements": ["Ulug Ok"],
+        "culture": "karluk"
+    },
+    "Kazakh": {
+        "settlements": ["Zhairem", "Kengir"],
+        "culture": "pecheneg"
+    },
+    "Balkhash": {
+        "settlements": ["Gulshat", "Shashubay"],
+        "culture": "cuman"
+    },
+    "Kimak": {
+        "settlements": ["Atasu", "Tengiz"],
+        "culture": "cuman"
+    },
+    "Lakomelza": {
+        "settlements": ["Dessye", "Tigaja", "Metene", "Ziya", "Kembolcha", "Habru", "Cherkwa"],
+        "culture": "ethiopian"
+    },
+    "Tigrinya": {
+        "settlements": ["Bilamba", "Golonco", "Tigrinya", "Adenna", "Adi Ramets", "Zagamat", "Amba Maderiya"],
+        "culture": "ethiopian"
+    },
+    "Yarkand": {
+        "settlements": ["Yarkand", "Yecheng"],
+        "culture": "saka"
+    },
+    "Kashgar": {
+        "settlements": ["Kashgar", "Xiuxun"],
+        "culture": "saka"
+    },
+    "Lusignan": {
+        "settlements": ["Charroux", "Niort", "Civray", "Lusignan", "Stmaixent", "Maillezais", "Melle", "Confolens"],
+        "culture": "occitan"
+    },
+    "Khotan": {
+        "settlements": ["Jiandu", "Khotan", "Jingjue"],
+        "culture": "saka"
+    },
+    "Cherchen": {
+        "settlements": ["Endere", "Cherchen"],
+        "culture": "tocharian"
+    },
+    "Charkliq": {
+        "settlements": ["Charkliq", "Miran"],
+        "culture": "tocharian"
+    },
+    "Karashar": {
+        "settlements": ["Karashar", "Tiemenguan", "Korla", "Weixu"],
+        "culture": "tocharian"
+    },
+    "Kucha": {
+        "settlements": ["Subashi", "Kumtura", "Kizil", "Kucha"],
+        "culture": "tocharian"
+    },
+    "Aksu": {
+        "settlements": ["Aksu Mongolia", "Wensu"],
+        "culture": "tocharian"
+    },
+    "Kara Khoja": {
+        "settlements": ["Turfan", "Kara Khoja", "Astana", "Jiaohe", "Bezeklik"],
+        "culture": "tocharian"
+    },
+    "Loulan": {
+        "settlements": ["Kroran", "Lopnor", "Loulan"],
+        "culture": "tocharian"
+    },
+    "Dunhuang": {
+        "settlements": ["Dunhuang", "Fangpan", "Yueyaquan", "Mogao", "Yumenquan"],
+        "culture": "han"
+    },
+    "Luntai": {
+        "settlements": ["Luntai", "Fukang", "Changji"],
+        "culture": "tocharian"
+    },
+    "La Marche": {
+        "settlements": ["Bellac", "Gueret", "Aubusson", "Lasouterraine", "Jouillat", "Crozant", "Boussac", "Bourganeuf"],
+        "culture": "occitan"
+    },
+    "Kumul": {
+        "settlements": ["Kumul", "Piqan"],
+        "culture": "tocharian"
+    },
+    "Altay": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Beshbaliq": {
+        "settlements": ["Mori", "Dunkheger", "Gucheng", "Jiangjunmiao", "Hou Pulei", "Yulishi"],
+        "culture": "uyghur"
+    },
+    "Aj Bogd": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Muztau": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Tsagaannuur": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Ikh Bogd": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Kara Khorum": {
+        "settlements": ["Noin Ula"],
+        "culture": "uyghur"
+    },
+    "Khangai": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Kyzyl": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Bourbon": {
+        "settlements": ["Murat", "Souvigny", "Moulins", "Montpensier", "Vichy", "Bourbon", "Lancy"],
+        "culture": "old_frankish"
+    },
+    "Baygal": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Otuken": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Gorgol": {
+        "settlements": [],
+        "culture": "kirghiz"
+    },
+    "Erchis": {
+        "settlements": ["Korya"],
+        "culture": "kirghiz"
+    },
+    "Gilgit": {
+        "settlements": ["Danyor", "Gilgit", "Chitral"],
+        "culture": "panjabi"
+    },
+    "Tashkurgan": {
+        "settlements": ["Jianggala", "Tashkurgan"],
+        "culture": "saka"
+    },
+    "Skardu": {
+        "settlements": ["Huldi", "Skardu"],
+        "culture": "zhangzhung"
+    },
+    "Diskit": {
+        "settlements": ["Thirit", "Diskit"],
+        "culture": "zhangzhung"
+    },
+    "Leh": {
+        "settlements": ["Keylong", "Leh", "Gya", "Shey"],
+        "culture": "zhangzhung"
+    },
+    "Kangra": {
+        "settlements": ["Nurpur", "Kangra", "Shimla"],
+        "culture": "panjabi"
+    },
+    "Limousin": {
+        "settlements": ["Chalus", "Limoges", "Ventadour", "Rochechouart", "Thiviers", "Turenne", "Stleonard", "Comborn"],
+        "culture": "occitan"
+    },
+    "Garhwal": {
+        "settlements": ["Srinagar", "Badrinath", "Devalghar"],
+        "culture": "hindustani"
+    },
+    "Kurmanchal": {
+        "settlements": ["Kartikeyapura", "Askot Kurmanchal", "Katarmal"],
+        "culture": "hindustani"
+    },
+    "Jumla": {
+        "settlements": ["Simikot", "Jumla"],
+        "culture": "nepali"
+    },
+    "Doti": {
+        "settlements": ["Dullu", "Dailekh"],
+        "culture": "nepali"
+    },
+    "Lumbini": {
+        "settlements": ["Bhairahawa"],
+        "culture": "nepali"
+    },
+    "Pokhara": {
+        "settlements": ["Muktinath", "Pokhara"],
+        "culture": "nepali"
+    },
+    "Mangyul": {
+        "settlements": ["Dzongka", "Tingri", "Shelkar", "Gyirong"],
+        "culture": "zhangzhung"
+    },
+    "Janakpur": {
+        "settlements": ["Birgunj", "Devghat", "Janakpur"],
+        "culture": "nepali"
+    },
+    "Kathmandu": {
+        "settlements": ["Pashupatinath", "Kathmandu", "Bhaktapur"],
+        "culture": "nepali"
+    },
+    "Limbuwan": {
+        "settlements": ["Taplejung", "Tambar"],
+        "culture": "nepali"
+    },
+    "Angouleme": {
+        "settlements": ["Jarnac", "Fontdouce", "Richemont", "Angouleme", "Larochefoucauld", "Latranchade", "Cognac", "Bassac"],
+        "culture": "occitan"
+    },
+    "Sikkim": {
+        "settlements": ["Gyalshing", "Mangan", "Gangdoz"],
+        "culture": "nepali"
+    },
+    "Paro": {
+        "settlements": ["Kyichu", "Paro", "Hungrel"],
+        "culture": "bodpa"
+    },
+    "Bumthang": {
+        "settlements": ["Bumthang", "Jambay", "Trongsa"],
+        "culture": "bodpa"
+    },
+    "Monyul": {
+        "settlements": ["Itanagar", "Sepla", "Tawang"],
+        "culture": "bodpa"
+    },
+    "Lhoyu": {
+        "settlements": ["Lhoyu", "Anini"],
+        "culture": "bodpa"
+    },
+    "Rutog": {
+        "settlements": ["Rutog", "Rawang Rutog"],
+        "culture": "zhangzhung"
+    },
+    "Tsaparang": {
+        "settlements": ["Tsaparang", "Tholing", "Tholinggompa"],
+        "culture": "zhangzhung"
+    },
+    "Gar": {
+        "settlements": ["Gar", "Senggezangbo", "Kunsa"],
+        "culture": "zhangzhung"
+    },
+    "Pangong": {
+        "settlements": ["Khumak", "Pangong"],
+        "culture": "zhangzhung"
+    },
+    "Kunlun": {
+        "settlements": [],
+        "culture": "zhangzhung"
+    },
+    "Bordeaux": {
+        "settlements": ["Blaye", "Lareole", "Bordeaux", "Bourg", "Libourne", "Lasauve", "Stemilion"],
+        "culture": "basque"
+    },
+    "Kyunglung": {
+        "settlements": ["Monicer"],
+        "culture": "zhangzhung"
+    },
+    "Purang": {
+        "settlements": ["Khorzhak", "Purang"],
+        "culture": "zhangzhung"
+    },
+    "Sakya": {
+        "settlements": ["Pelsakya", "Sakya", "Geding"],
+        "culture": "zhangzhung"
+    },
+    "Coqen": {
+        "settlements": [],
+        "culture": "zhangzhung"
+    },
+    "Gerze": {
+        "settlements": [],
+        "culture": "zhangzhung"
+    },
+    "Samtho": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Taktse": {
+        "settlements": ["Qonggyai", "Taktse"],
+        "culture": "bodpa"
+    },
+    "Gyantse": {
+        "settlements": ["Bainang", "Palcho", "Gyantse"],
+        "culture": "bodpa"
+    },
+    "Lhasa": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Shigatse": {
+        "settlements": ["Shalu", "Tashilhunpo", "Shigatse", "Samzhubze"],
+        "culture": "sumpa"
+    },
+    "Ormond": {
+        "settlements": ["Cahir", "Cashel", "Clonmel", "Lismore", "Roscrea", "Fethard", "Waterford", "Nenagh"],
+        "culture": "irish"
+    },
+    "Albret": {
+        "settlements": ["Gabarret", "Bazas", "Latestedebuch", "Roquefort", "Mimizan", "Tartas", "Labrit"],
+        "culture": "basque"
+    },
+    "Nyingchi": {
+        "settlements": ["Drakchi", "Nyingchi", "Lamaling"],
+        "culture": "tangut"
+    },
+    "Nagormo": {
+        "settlements": [],
+        "culture": "tangut"
+    },
+    "Fuqi": {
+        "settlements": ["Shatuo", "Fuqi"],
+        "culture": "tangut"
+    },
+    "Nangqen": {
+        "settlements": ["Tana", "Tana B"],
+        "culture": "tangut"
+    },
+    "Lingtsang": {
+        "settlements": ["Serxu"],
+        "culture": "tangut"
+    },
+    "Markam": {
+        "settlements": [],
+        "culture": "tangut"
+    },
+    "Dege": {
+        "settlements": ["Dzongsar", "Palpung", "Dege"],
+        "culture": "tangut"
+    },
+    "Nyima": {
+        "settlements": ["Nyima"],
+        "culture": "zhangzhung"
+    },
+    "Qamdo": {
+        "settlements": ["Riwoche", "Qamdo", "Karub"],
+        "culture": "tangut"
+    },
+    "Labourd": {
+        "settlements": ["Bayonne", "Sorde", "Dax", "Stsever", "Sauveterre", "Labastideclairence", "Aire"],
+        "culture": "basque"
+    },
+    "Pamir": {
+        "settlements": ["Kala Panja", "Vanj", "Daroot Korgon", "Zamr I Atish Parast"],
+        "culture": "sogdian"
+    },
+    "Jiuquan": {
+        "settlements": ["Kongtong", "Jiuquan", "Suzhou"],
+        "culture": "han"
+    },
+    "Ejin": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Yungguan": {
+        "settlements": ["Yungguan", "Shouchang"],
+        "culture": "han"
+    },
+    "Barkul": {
+        "settlements": [],
+        "culture": "uyghur"
+    },
+    "Dunkheger": {
+        "settlements": ["Mori", "Dunkheger", "Gucheng", "Jiangjunmiao", "Hou Pulei", "Yulishi"],
+        "culture": "uyghur"
+    },
+    "Kumtag": {
+        "settlements": ["Kumtag", "Chiting"],
+        "culture": "tocharian"
+    },
+    "Lopnor": {
+        "settlements": ["Lopnor"],
+        "culture": "tocharian"
+    },
+    "Navarra": {
+        "settlements": ["Olite", "Leyre", "Estella", "Tafalla", "Pamplona", "Carcastillo", "Sanguesa"],
+        "culture": "basque"
+    },
+    "Yuni": {
+        "settlements": ["Ruoqiang", "Yuni"],
+        "culture": "tocharian"
+    },
+    "Mingoi": {
+        "settlements": ["Shorshuq", "Mingoi", "Qigexing"],
+        "culture": "tocharian"
+    },
+    "Cadota": {
+        "settlements": ["Niya"],
+        "culture": "tocharian"
+    },
+    "Keriya": {
+        "settlements": ["Dandan Uilik", "Pimo", "Keriya"],
+        "culture": "saka"
+    },
+    "Karghalik": {
+        "settlements": ["Karghalik"],
+        "culture": "saka"
+    },
+    "Yopurga": {
+        "settlements": ["Jiashi", "Yopurga"],
+        "culture": "saka"
+    },
+    "Artux": {
+        "settlements": ["Atush"],
+        "culture": "saka"
+    },
+    "Uchturpan": {
+        "settlements": ["Uqturpan", "Yezheguan", "Wensu"],
+        "culture": "tocharian"
+    },
+    "Kubera": {
+        "settlements": ["Subashi", "Kumtura", "Kizil", "Kubera"],
+        "culture": "tocharian"
+    },
+    "Viscaya": {
+        "settlements": ["Bilbao", "Sansebastian", "Guernica", "Onate", "Vitoria", "Tolosa", "Irun", "Eibar"],
+        "culture": "basque"
+    },
+    "Dariya": {
+        "settlements": ["Fayd", "An Nibaj", "Zubala", "Al Ajfur", "At Talabiya", "Al Qaryatan"],
+        "culture": "levantine_arabic"
+    },
+    "Uwal": {
+        "settlements": ["Muharraq", "Umm As Sabaan", "Manama", "Sitra", "Aldur", "Umm Al Nasan", "Jidda", "Hamala"],
+        "culture": "bedouin_arabic"
+    },
+    "Zabid": {
+        "settlements": ["Mukha", "Zabid", "Al Mahjam", "Hays", "Fasal", "Ghalafiqa", "Mawr"],
+        "culture": "bedouin_arabic"
+    },
+    "Najran": {
+        "settlements": ["Najran", "Huth", "Sada"],
+        "culture": "bedouin_arabic"
+    },
+    "Al Ahqaf": {
+        "settlements": ["Al Ahqaf", "Sabwa", "Al Abr"],
+        "culture": "bedouin_arabic"
+    },
+    "Tihama": {
+        "settlements": ["Attar", "Abs", "Hali", "As Suqaiq", "Harad", "Hamr", "Bays"],
+        "culture": "bedouin_arabic"
+    },
+    "Khaybar": {
+        "settlements": ["Haura", "Rabig", "Khaybar", "Algiar", "Soridan", "Badr", "Yanbu"],
+        "culture": "bedouin_arabic"
+    },
+    "Maragha": {
+        "settlements": ["Kursara", "Maragheh", "Miyaneh"],
+        "culture": "kurdish"
+    },
+    "Badghis": {
+        "settlements": ["Zurabad", "Kusuya", "Malin", "Kuhsim", "Buzgan", "Pushang", "Jabal Al Adda"],
+        "culture": "persian"
+    },
+    "Kanj Rustaq": {
+        "settlements": ["Diza", "Kusak", "Baghsur"],
+        "culture": "persian"
+    },
+    "Asturias De Santillana": {
+        "settlements": ["Santillanadelmar", "Santander", "Laredo", "Santona", "Suances", "Sanvicente", "Reinosa", "Camargo", "Castrourdiales"],
+        "culture": "visigothic"
+    },
+    "Guzgan": {
+        "settlements": ["Naryan", "Faryab", "Andkhud", "Usbuman", "Jahudan", "Talaqan", "Qasrahnaf"],
+        "culture": "persian"
+    },
+    "Amol": {
+        "settlements": ["Amol", "Akhsisak", "Zamm"],
+        "culture": "persian"
+    },
+    "Sarakhs": {
+        "settlements": ["Mazduran", "Dandanqan", "Maihana", "Sarakhs"],
+        "culture": "persian"
+    },
+    "Vakhan": {
+        "settlements": ["Sughnan", "Daritubat", "Vakhan", "Ishkashim"],
+        "culture": "sogdian"
+    },
+    "Chaghaniyan": {
+        "settlements": ["Di-L-Kifl", "Sapoltepa", "Termez", "Shuman", "Di-L-Qarnain", "Chaghaniyan", "Kalif"],
+        "culture": "sogdian"
+    },
+    "Nakhshab": {
+        "settlements": ["Paykand", "Nakhsab"],
+        "culture": "sogdian"
+    },
+    "Khojand": {
+        "settlements": ["Tunket", "Khavakend", "Sokh", "Asht", "Kendibadam", "Khojand", "Ilaq"],
+        "culture": "sogdian"
+    },
+    "Badakhshan": {
+        "settlements": ["Badakhshan", "Jerm", "Kerran", "Kamar", "Rustaq", "Jarf", "Panj"],
+        "culture": "sogdian"
+    },
+    "Khaylam": {
+        "settlements": ["Wankath", "Ardalankath", "Najm", "Miyanrudhan", "Khaylam", "Kasan", "Akhsikath"],
+        "culture": "sogdian"
+    },
+    "Asturias De Oviedo": {
+        "settlements": ["Cangasdelnarcea", "Villaviciosa", "Norena", "Gijon", "Tineo", "Luarca", "Oviedo", "Cangasdeonis"],
+        "culture": "visigothic"
+    },
+    "Lhatok": {
+        "settlements": ["Gonjo"],
+        "culture": "tangut"
+    },
+    "Mustang": {
+        "settlements": ["Tetang", "Lo", "Chhonhup"],
+        "culture": "zhangzhung"
+    },
+    "Lhunze": {
+        "settlements": [],
+        "culture": "bodpa"
+    },
+    "Bome": {
+        "settlements": ["Zhamo"],
+        "culture": "tangut"
+    },
+    "Banbar": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Medog": {
+        "settlements": [],
+        "culture": "bodpa"
+    },
+    "Lhunzhub": {
+        "settlements": ["Reting"],
+        "culture": "sumpa"
+    },
+    "Kunggar": {
+        "settlements": ["Kunggar", "Drigung"],
+        "culture": "sumpa"
+    },
+    "Amdo": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Xainza": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Coruna": {
+        "settlements": ["Triacastela", "Mondonedo", "Viveiro", "Lugo", "Corunna", "Ferrol", "Burela", "Villalba"],
+        "culture": "suebi"
+    },
+    "Ogliastra": {
+        "settlements": ["Tortoli", "Ballao", "Jerzu", "Bari Sardo", "Urzulei", "Ogliastra", "Muravera"],
+        "culture": "italian"
+    },
+    "Lhatse": {
+        "settlements": ["Lhatse", "Gyangbumoche"],
+        "culture": "zhangzhung"
+    },
+    "Zhongba": {
+        "settlements": ["Labrang"],
+        "culture": "zhangzhung"
+    },
+    "Gegyai": {
+        "settlements": ["Zhungpa", "Gegyai"],
+        "culture": "zhangzhung"
+    },
+    "Qangtang": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Tsakha": {
+        "settlements": [],
+        "culture": "zhangzhung"
+    },
+    "Gyesar": {
+        "settlements": [],
+        "culture": "zhangzhung"
+    },
+    "Mainling": {
+        "settlements": [],
+        "culture": "bodpa"
+    },
+    "Yumen": {
+        "settlements": ["Baoen", "Dongshuwo", "Yumen", "Xiaxihao"],
+        "culture": "han"
+    },
+    "Delingha": {
+        "settlements": ["Delingha"],
+        "culture": "tangut"
+    },
+    "Santiago": {
+        "settlements": ["Vilagarcia", "Verin", "Tuy", "Pontevedra", "Padron", "Vigo", "Ourense", "Santiago"],
+        "culture": "suebi"
+    },
+    "Qaidam": {
+        "settlements": [],
+        "culture": "tangut"
+    },
+    "Lenghu": {
+        "settlements": [],
+        "culture": "tangut"
+    },
+    "Arjin": {
+        "settlements": [],
+        "culture": "sumpa"
+    },
+    "Tanggula": {
+        "settlements": ["Tongtian"],
+        "culture": "sumpa"
+    },
+    "Gallura": {
+        "settlements": ["Bicinara", "Posada", "Dorgali", "Galtelli", "Aggius", "Olbia", "Lungone", "Nuoro"],
+        "culture": "italian"
+    },
+    "Zadoi": {
+        "settlements": ["Qapugtang"],
+        "culture": "tangut"
+    },
+    "Torres": {
+        "settlements": ["Valledoria", "Portotorres", "Alghero", "Sassari", "Ottana", "Bosa", "Oschiri", "Ardara"],
+        "culture": "italian"
+    },
+    "Cinarca": {
+        "settlements": ["Bonifacio", "Filitosa", "Ajaccio", "Portevecchio", "Cinarca", "Propriano", "Bastelicaccia", "Sartene"],
+        "culture": "italian"
+    },
+    "Dulan": {
+        "settlements": ["Reshui", "Dulan"],
+        "culture": "tangut"
+    },
+    "Nedong": {
+        "settlements": ["Phagmodru", "Nedong", "Zetang"],
+        "culture": "bodpa"
+    },
+    "Porto": {
+        "settlements": ["Guimaraes", "Moncao", "Arcosdevaldevez", "Pontedelima", "Braga", "Porto", "Barcelos", "Vianadocastelo"],
+        "culture": "suebi"
+    },
+    "Coimbra": {
+        "settlements": ["Montereal", "Pedondo", "Viseu", "Cantanhede", "Condeixa", "Coimbra", "Aveiro", "Penela"],
+        "culture": "suebi"
+    },
+    "Leinster": {
+        "settlements": ["Wexford", "Naas", "Carlow", "Leighlin", "Enniscorthy", "Glendalough", "Ferns", "Arklow"],
+        "culture": "irish"
+    },
+    "Lisboa": {
+        "settlements": ["Santarem", "Alenquer", "Atouguia", "Lisboa", "Alcobaca", "Batalha", "Setubal"],
+        "culture": "visigothic"
+    },
+    "Alcacer Do Sal": {
+        "settlements": ["Santiagodocacem", "Alvito", "Alcacovas", "Espinheiro", "Alcacerdosal", "Sines", "Grandola", "Montemoronovo"],
+        "culture": "visigothic"
+    },
+    "Silves": {
+        "settlements": ["Castroverde", "Silves", "Aljustrel", "Ourique", "Monchique", "Odemira", "Almodovar", "Lagos"],
+        "culture": "visigothic"
+    },
+    "Faro": {
+        "settlements": ["Saobrasdealportel", "Alcoutim", "Loule", "Faro", "Castromarim", "Aljezur", "Olhao", "Tavira"],
+        "culture": "visigothic"
+    },
+    "Niebla": {
+        "settlements": ["Huelva", "Niebla", "Lepe", "Nerva", "Aljaraque", "Moguer", "Almonte", "Gibraleon"],
+        "culture": "visigothic"
+    },
+    "Cadiz": {
+        "settlements": ["Jerez", "Arcos", "Alcaladelosgazules", "Cadiz", "Sanfernando", "Medinasidonia", "Sanlucadebarrameda", "Sanjosedelvalle"],
+        "culture": "visigothic"
+    },
+    "Algeciras": {
+        "settlements": ["Estepona", "Casares", "Tarifa", "Sanroque", "Gibraltar", "Jimenadelafrontera", "Algericas", "Ronda"],
+        "culture": "visigothic"
+    },
+    "Malaga": {
+        "settlements": ["Malaga", "Tamisa", "Antequera", "Coin", "Benalmadena", "Cartajima", "Velezmalaga", "Suel"],
+        "culture": "visigothic"
+    },
+    "Almeria": {
+        "settlements": ["Baza", "Motril", "Almeria", "Vera", "Purchena", "Albox", "Pechina", "Berja"],
+        "culture": "visigothic"
+    },
+    "Murcia": {
+        "settlements": ["Alcantarilla", "Cartagena", "Medinasiyasa", "Molinalaseca", "Lorca", "Murcia", "Nogalte", "Yecla"],
+        "culture": "visigothic"
+    },
+    "Hereford": {
+        "settlements": ["Ewyas Harold", "Hereford", "Leominster", "Clifford", "Archenfield", "Brobury", "Ledbury", "St Ethelberts"],
+        "culture": "welsh"
+    },
+    "Denia": {
+        "settlements": ["Benissa", "Denia", "Alicante", "Elche", "Orihuela", "Villena", "Castalla", "Albatera"],
+        "culture": "visigothic"
+    },
+    "Valencia": {
+        "settlements": ["Chiva", "Gandia", "Cuartdepoblet", "Torrent", "Valencia", "Jativa", "Alberique", "Alacuas"],
+        "culture": "visigothic"
+    },
+    "Castellon": {
+        "settlements": ["Nules", "Castellon", "Alpuente", "Morella", "Vilarreal", "Alcalaten", "Vinaros", "Burriana"],
+        "culture": "visigothic"
+    },
+    "Tarragona": {
+        "settlements": ["Cambrils", "Amposta", "Tarragona", "Vendrell", "Spantortosa", "Reus", "Montblanc", "Sancugat"],
+        "culture": "visigothic"
+    },
+    "Albarracin": {
+        "settlements": ["Montalban", "Hijar", "Alcaniz", "Calanda", "Calamocha", "Teruel", "Utrillas", "Albarracin"],
+        "culture": "visigothic"
+    },
+    "Calatayud": {
+        "settlements": ["Cimballa", "Munebrega", "Calmarza", "Alhamadearagon", "Nuevalos", "Calatayud", "Piedra", "Daroca"],
+        "culture": "visigothic"
+    },
+    "Molina": {
+        "settlements": ["Elpedregal", "Hinojosa", "Cabanillasdelcampo", "Elcasar", "Olmeda", "Maranchon", "Pinilla", "Molina"],
+        "culture": "visigothic"
+    },
+    "Cuenca": {
+        "settlements": ["Siguenza", "Ucles", "Laspedroneras", "Guadalajara", "Tarancon", "Villanuevadelajara", "Motadelcuervo", "Cuenca"],
+        "culture": "visigothic"
+    },
+    "La Mancha": {
+        "settlements": ["Quintanardelrey", "Lagineta", "Alarcon", "Laroda", "Barrax", "Munera", "Jorquera", "Tarazona"],
+        "culture": "visigothic"
+    },
+    "Almansa": {
+        "settlements": ["Hellin", "Almansa", "Villarrobledo", "Alcaladeljucar", "Tobarra", "Caudete", "Pozocanada", "Albacete"],
+        "culture": "visigothic"
+    },
+    "Dyfed": {
+        "settlements": ["Llandeilo", "Narberth", "Kidwelly", "St Davids", "Carmarthen", "Haverford", "Pembroke", "Dinefwr"],
+        "culture": "welsh"
+    },
+    "Granada": {
+        "settlements": ["Granada", "Elvira", "Huelma", "Moclin", "Guadix", "Iznajar", "Jaen", "Baeza"],
+        "culture": "visigothic"
+    },
+    "Cordoba": {
+        "settlements": ["Canetedelastorres", "Cabra", "Cordoba", "Belalcazar", "Andujar", "Alcolea", "Martos", "Lucena"],
+        "culture": "visigothic"
+    },
+    "Sevilla": {
+        "settlements": ["Sevilla", "Carmona", "Ecija", "Sevimoron", "Doshermanas", "Laalgaba", "Utrera"],
+        "culture": "visigothic"
+    },
+    "Aracena": {
+        "settlements": ["Aracena", "Facanias", "Cortegana", "Alajar", "Calanas", "Galaroza", "Italica", "Almonasterlareal"],
+        "culture": "visigothic"
+    },
+    "Badajoz": {
+        "settlements": ["Merida", "Villalbadelosbarros", "Guarena", "Fuentedelmaestre", "Badajoz", "Jerezdeloscaballeros", "Almendralejo", "Zafra"],
+        "culture": "visigothic"
+    },
+    "Mertola": {
+        "settlements": ["Portel", "Serpa", "Moura", "Mertola", "Noudal", "Mourao", "Monsaraz", "Beja"],
+        "culture": "visigothic"
+    },
+    "Evora": {
+        "settlements": ["Marvao", "Evora", "Crato", "Portalegre", "Castelodevide", "Monforte", "Avis", "Ouguela"],
+        "culture": "visigothic"
+    },
+    "Castelo Branco": {
+        "settlements": ["Sabugal", "Castelobranco", "Trancoso", "Acores", "Covilha", "Guarda", "Almeida", "Pinhel"],
+        "culture": "suebi"
+    },
+    "Braganza": {
+        "settlements": ["Castelomelhor", "Azinhoso", "Chaves", "Vilareal", "Mogadouro", "Castelorodrigo", "Braganza", "Torredemoncorvo"],
+        "culture": "suebi"
+    },
+    "Astorga": {
+        "settlements": ["Toreno", "Bembibre", "Camponaraya", "Astorga", "Cacabelos", "Ponferrada", "Fabero", "Ribadelago"],
+        "culture": "suebi"
+    },
+    "Glamorgan": {
+        "settlements": ["Loughor", "Llandaff", "Caerphilly", "Ogmore", "Cardiff", "Neath", "Margam", "Swansea"],
+        "culture": "welsh"
+    },
+    "Leon": {
+        "settlements": ["Cistierna", "Villablino", "Larobla", "Sanpedrodeperix", "Saldana", "Leon", "Sahagun", "Valenciadecampos"],
+        "culture": "visigothic"
+    },
+    "Zamora": {
+        "settlements": ["Benavente", "Fermoselle", "Corrales", "Fuentesauco", "Sanabria", "Toro", "Zamora", "Polvorosa"],
+        "culture": "visigothic"
+    },
+    "Salamanca": {
+        "settlements": ["Albadetormes", "Ciudadrodrigo", "Salbejar", "Carbajosadelasagrada", "Lumbrales", "Salamanca", "Bracamonte", "Terradillos"],
+        "culture": "visigothic"
+    },
+    "Alcantara": {
+        "settlements": ["Alcantara", "Lasnavasdelmadrono", "Ceclavin", "Moraleja", "Lamata", "Racharachel", "Coria", "Brozas"],
+        "culture": "visigothic"
+    },
+    "Plasencia": {
+        "settlements": ["Ventadelmoral", "Montehermoso", "Jarandilla", "Hervas", "Plasencia", "Talayuela", "Jaraiz", "Lazarza"],
+        "culture": "visigothic"
+    },
+    "Caceres": {
+        "settlements": ["Alia", "Logrosan", "Alburquerque", "Arroyodelalluz", "Alcuescar", "Guadalupe", "Caceres", "Trujillo"],
+        "culture": "visigothic"
+    },
+    "Calatrava": {
+        "settlements": ["Calatrava", "Alcazardesanjuan", "Villareal", "Alarcos", "Medellin", "Caracuel", "Almadeo", "Almodovardelcampo"],
+        "culture": "visigothic"
+    },
+    "Toledo": {
+        "settlements": ["Fuensalida", "Madrid", "Orgaz", "Talavera", "Consuegra", "Tolemora", "Illescas", "Toledo"],
+        "culture": "visigothic"
+    },
+    "Valladolid": {
+        "settlements": ["Medinadelcampo", "Tordesillas", "Penafiel", "Iscar", "Simancas", "Segovia", "Valladolid", "Avila"],
+        "culture": "visigothic"
+    },
+    "Burgos": {
+        "settlements": ["Palencia", "Burgos", "Aguilardecampo", "Mirandadeebro", "Castrobarte", "Carrion", "Silos", "Arandadeduero"],
+        "culture": "visigothic"
+    },
+    "Austisland": {
+        "settlements": ["Akureyri", "Glaumbaer", "Valpjotstadur", "Kirkjubaer", "Husavik", "Goddalir", "Holar", "Hrisey"],
+        "culture": "norse"
+    },
+    "Gwent": {
+        "settlements": ["Tintern", "Caerleon", "Monmouth", "Brecon", "Chepstow", "Abergavenny", "Caerwent", "Newport"],
+        "culture": "welsh"
+    },
+    "Soria": {
+        "settlements": ["Soria", "Osma", "Almazan", "Sanleonardodeyague", "Gormaz", "Covaleda", "Castromoro", "Medinacelli"],
+        "culture": "visigothic"
+    },
+    "Najera": {
+        "settlements": ["Arnedo", "Logrone", "Haro", "Alfara", "Santodomingodelacalzada", "Zizurmayor", "Calahorra", "Najera"],
+        "culture": "basque"
+    },
+    "Zaragoza": {
+        "settlements": ["Alagon", "Zaragoza", "Veruela", "Borja", "Epila", "Medianadearagon", "Caspe", "Ejea"],
+        "culture": "visigothic"
+    },
+    "Lleida": {
+        "settlements": ["Balaguer", "Agramunt", "Cervera", "Lleida", "Solsona", "Borgesblanques", "Verdu", "Tarrega"],
+        "culture": "visigothic"
+    },
+    "Barcelona": {
+        "settlements": ["Barcelona", "Vic", "Igualada", "Osona", "Berga", "Provencana", "Manresa", "Vallparadis"],
+        "culture": "visigothic"
+    },
+    "Empuries": {
+        "settlements": ["Banyoles", "Cerdana", "Castelldaro", "Girona", "Figueras", "Labisbaldemporda", "Empuries", "Besalu"],
+        "culture": "visigothic"
+    },
+    "Urgell": {
+        "settlements": ["Valledebohi", "Viella", "Pallars", "Elpuidesegur", "Urgell", "Puigcerda", "Tremp", "Suert"],
+        "culture": "visigothic"
+    },
+    "Alto Aragon": {
+        "settlements": ["Almudevar", "Huesca", "Loarre", "Alquezar", "Ayerbe", "Jaca", "Barbastro", "Uncastillo"],
+        "culture": "basque"
+    },
+    "Bearn": {
+        "settlements": ["Lescar", "Pau", "Montaner", "Mauleonlicharre", "Oloron", "Orthez", "Tarbes", "Morlaas"],
+        "culture": "basque"
+    },
+    "Armagnac": {
+        "settlements": ["Lectoure", "Laplume", "Auch", "Eauze", "Castelnau", "Lisle", "Mirande"],
+        "culture": "occitan"
+    },
+    "Gloucester": {
+        "settlements": ["Cirencester", "Winchcombe", "Tewkesbury", "Hailes", "Gloucester", "Sudeley", "Cheltenham", "Bristol"],
+        "culture": "saxon"
+    },
+    "Foix": {
+        "settlements": ["Usson", "Foix", "Mirepoix", "Stgaudens", "Roquefeuil", "Stbertrand", "Montsegur"],
+        "culture": "visigothic"
+    },
+    "Rosello": {
+        "settlements": ["Elna", "Oltrera", "Perpinya", "Prada", "Cuixa", "Canigo", "Cotlliure", "Ceret"],
+        "culture": "visigothic"
+    },
+    "Narbonne": {
+        "settlements": ["Puisserguier", "Queribus", "Stponsdethomieres", "Narbonne", "Beziers", "Agde", "Castres", "Albi"],
+        "culture": "visigothic"
+    },
+    "Carcassonne": {
+        "settlements": ["Minerve", "Carcassonne", "Saissac", "Alet", "Lastours", "Termes", "Lagrasse", "Cabaret"],
+        "culture": "visigothic"
+    },
+    "Toulouse": {
+        "settlements": ["Montauban", "Muret", "Castelnaudary", "Montgiscard", "Lombez", "Lavaur", "Toulouse", "Hautpoul"],
+        "culture": "occitan"
+    },
+    "Agen": {
+        "settlements": ["Cahors", "Rocamadour", "Figeac", "Moissac", "Penne", "Agen", "Luzech", "Blanquefort"],
+        "culture": "occitan"
+    },
+    "Perigord": {
+        "settlements": ["Chancelade", "Sarlat", "Bergerac", "Perigueux", "Baneuil", "Biron", "Bonaguil", "Auberoche"],
+        "culture": "occitan"
+    },
+    "Auvergne": {
+        "settlements": ["Domeyrat", "Brioude", "Carlat", "Aurillac", "Murol", "Tournoel", "Mozac", "Clermont"],
+        "culture": "occitan"
+    },
+    "Rouergue": {
+        "settlements": ["Villefranche", "Estaing", "Rodez", "Millau", "Najac", "Vabres", "Staffrique", "Caylus"],
+        "culture": "occitan"
+    },
+    "Gevaudan": {
+        "settlements": ["Mende", "Tournel", "Stsauveur", "Florac", "Marvejols", "Lepuy", "Grezes", "Apchier"],
+        "culture": "visigothic"
+    },
+    "Oxford": {
+        "settlements": ["Oxford", "Abingdon", "Banbury", "Wallingford", "Aylesbury", "Buckingham", "Eynsham", "Reading"],
+        "culture": "saxon"
+    },
+    "Montpellier": {
+        "settlements": ["Beaucaire", "Maguelone", "Montpellier", "Aiguesmortes", "Saintguilhemledesert", "Bagnolssurceze", "Nimes", "Melgueil"],
+        "culture": "visigothic"
+    },
+    "Provence": {
+        "settlements": ["Aix", "Castellane", "Frejus", "Tarascon", "Marseille", "Grimaud", "Arles", "Grasse"],
+        "culture": "visigothic"
+    },
+    "Venaissin": {
+        "settlements": ["Carpentras", "Orange", "Chateauneufdupape", "Mondragon", "Avignon", "Stpaul", "Venasque", "Cavaillon"],
+        "culture": "visigothic"
+    },
+    "Viviers": {
+        "settlements": ["Largentiere", "Joyeuse", "Aubenas", "Viviers", "Privas", "Albalaromaine", "Tournon", "Lecheylard"],
+        "culture": "visigothic"
+    },
+    "Forez": {
+        "settlements": ["Chalmazel", "Montbrison", "Couzan", "Charlieu", "Feurs", "Stetienne", "Thiers", "Roanne"],
+        "culture": "occitan"
+    },
+    "Macon": {
+        "settlements": ["Davaye", "Beaujeu", "Fuisse", "Cluny", "Berze", "Macon", "Villefranchesursaone", "Lugny"],
+        "culture": "old_frankish"
+    },
+    "Charolais": {
+        "settlements": ["Montstvincent", "Paray", "Perrecy", "Digoine", "Joncy", "Charolles", "Toulonsurarroux", "Semurenbrionnais"],
+        "culture": "old_frankish"
+    },
+    "Lyon": {
+        "settlements": ["Stjeanbaptiste", "Irigny", "Chessy", "Lyon", "Lacenas", "Brindas", "Pusignan", "Anse"],
+        "culture": "old_frankish"
+    },
+    "Dauphine Viennois": {
+        "settlements": ["Montelimar", "Valence", "Chartreuse", "Albon", "Valreas", "Grenoble", "Vienne", "Stantoine"],
+        "culture": "occitan"
+    },
+    "Forcalquier": {
+        "settlements": ["Vaison", "Gap", "Briancon", "Nyons", "Sisteron", "Forcalquier", "Embrun", "Apt"],
+        "culture": "visigothic"
+    },
+    "Wiltshire": {
+        "settlements": ["Wilton", "Sarum", "Ramsbury", "Malmesbury", "Clarendon", "Salisbury", "Marlborough", "Devizes"],
+        "culture": "saxon"
+    },
+    "Nice": {
+        "settlements": ["Mentone", "Campogrosso", "Nizza", "Lantosque", "Sanremo", "Contes", "Antibes", "Monaco"],
+        "culture": "lombard"
+    },
+    "Saluzzo": {
+        "settlements": ["Cuneo", "Verzuolo", "Paesana", "Savigliano", "Caraglio", "Busca", "Saluzzo"],
+        "culture": "lombard"
+    },
+    "Monferrato": {
+        "settlements": ["Asti", "Casale", "Monferrato", "Acqui", "Tortona", "Alba", "Canelli", "Biella"],
+        "culture": "lombard"
+    },
+    "Genoa": {
+        "settlements": ["Ventimiglia", "Luna", "Albenga", "Genoa", "Savona", "Chiavari", "Rapallo", "Fosdinovo"],
+        "culture": "lombard"
+    },
+    "Pavia": {
+        "settlements": ["Bobbio", "Alessandria", "Pavia", "Voghera", "Colorno", "Montebello", "Piacenza", "Casteggio"],
+        "culture": "lombard"
+    },
+    "Lombardia": {
+        "settlements": ["Milano", "Vigevano", "Legnano", "Lodi", "Chiavenna", "Como", "Monza", "Maggiore"],
+        "culture": "lombard"
+    },
+    "Piemonte": {
+        "settlements": ["Auriate", "Torino", "Settimo", "Ferrero", "Crevacuore", "Messarano", "Novara", "Ivrea"],
+        "culture": "lombard"
+    },
+    "Savoie": {
+        "settlements": ["Bussoleno", "Montjovet", "Aosta", "Pombia", "Vercelli", "Ciamberi", "Savosusa", "Tarentaise"],
+        "culture": "old_frankish"
+    },
+    "Valais": {
+        "settlements": ["Aigle", "Monthey", "Siders", "Brig", "Greyerz", "Chateaudoex", "Sitten", "Martigny"],
+        "culture": "german"
+    },
+    "Geneve": {
+        "settlements": ["Thonon", "Romainmotier", "Lausanne", "Echallens", "Orbe", "Nyon", "Geneve", "Aubonne"],
+        "culture": "old_frankish"
+    },
+    "Surrey": {
+        "settlements": ["Woking", "Southwark", "Chertsey", "Farnham", "Croydon", "Lambeth", "Guildford", "Waverley"],
+        "culture": "saxon"
+    },
+    "Chalons": {
+        "settlements": ["Tournus", "Chamilly", "Brancion", "Stjeandelosne", "Chalon", "Seurre", "Cuisery", "Louhans"],
+        "culture": "old_frankish"
+    },
+    "Neuchatel": {
+        "settlements": ["Fribourg", "Neuchatel", "Stimier", "Grandson", "Murten", "Avences", "Yverdon", "Estavayer"],
+        "culture": "german"
+    },
+    "Aargau": {
+        "settlements": ["Basel", "Solothurn", "Schaffhausen", "Lenzburg", "Laufenburg", "Aargau", "Habsburg"],
+        "culture": "german"
+    },
+    "Orvieto": {
+        "settlements": ["Orvieto", "Otricoli", "Ciconia", "Alviano", "Montecastrilli", "Amelia", "Narni", "Baschi"],
+        "culture": "italian"
+    },
+    "Bern": {
+        "settlements": ["Kyburg", "Bern", "Interlaken", "Sursee", "Langenthal", "Luzern", "Sempach", "Biel"],
+        "culture": "german"
+    },
+    "Schwyz": {
+        "settlements": ["Zug", "Zurich", "Stans", "Schwyz", "Winterthur", "Glarus", "Engelberg", "Altdorf"],
+        "culture": "german"
+    },
+    "Grisons": {
+        "settlements": ["Bellinzona", "Domo", "Musso", "Mendrisio", "Disentis", "Lugano", "Locarno", "Biasca"],
+        "culture": "german"
+    },
+    "Chur": {
+        "settlements": ["Davos", "Maienfeld", "Illanz", "Glurns", "Churwalden", "Chur", "Thusis", "Zuoz"],
+        "culture": "german"
+    },
+    "St Gallen": {
+        "settlements": ["Vaduz", "Altstatten", "Herisau", "Frauenfeld", "Appenzell", "Lichtensteig", "Stgallen", "Rheineck"],
+        "culture": "german"
+    },
+    "Schwaben": {
+        "settlements": ["Lindau", "Heiligenberg", "Hohenberg", "Wangen", "Konstanz", "Uberlingen", "Friedrichshafen", "Tubingen"],
+        "culture": "german"
+    },
+    "Sussex": {
+        "settlements": ["Chichester", "Lewes", "Pevensey", "Arundel", "Bramber", "Hastings", "Bodiam", "Rye"],
+        "culture": "saxon"
+    },
+    "Breisgau": {
+        "settlements": ["Offenburg", "Zahringen", "Rottweil", "Lohrrach", "Freiburg", "Breisach", "Stblasien", "Lahr"],
+        "culture": "german"
+    },
+    "Furstenberg": {
+        "settlements": ["Zollern", "Baar", "Donaueschingen", "Haslach", "Furstenberg", "Wolfach", "Hirsau", "Villingen"],
+        "culture": "german"
+    },
+    "Ulm": {
+        "settlements": ["Ulm", "Zwiefalten", "Biberach", "Goppingen", "Isny", "Memmingen", "Erbach", "Teck"],
+        "culture": "german"
+    },
+    "Wurttemberg": {
+        "settlements": ["Asperg", "Esslingen", "Waiblingen", "Stuttgart", "Gmund", "Staufen", "Reutlingen", "Heilbronn"],
+        "culture": "german"
+    },
+    "Wurzburg": {
+        "settlements": ["Aschaffenburg", "Wurzburg", "Schwarzenberg", "Theiheim", "Mainderheim", "Marienberg", "Schweinfurt", "Hammelburg"],
+        "culture": "german"
+    },
+    "Thuringen": {
+        "settlements": ["Schmalkalden", "Salzungen", "Eichsfeld", "Muhlhausen", "Arnstadt", "Reuss", "Henneberg", "Erfurt"],
+        "culture": "german"
+    },
+    "Weimar": {
+        "settlements": ["Weimar", "Nordhausen", "Memelsen", "Gotha", "Apoldoa", "Walkenried", "Gera", "Jena"],
+        "culture": "old_saxon"
+    },
+    "Braunschweig": {
+        "settlements": ["Braunschweig", "Waldeck", "Gandersheim", "Bielefeld", "Helmstedt", "Hildesheim", "Wolfenbuttel"],
+        "culture": "old_saxon"
+    },
+    "Luneburg": {
+        "settlements": ["Bardowick", "Reppenstedt", "Evern", "Uelzen", "Luneburg", "Gifhorn", "Ludersburg", "Thomasburg"],
+        "culture": "old_saxon"
+    },
+    "Celle": {
+        "settlements": ["Celle", "Hannover", "Wittingen", "Hermannsburg", "Nienburg", "Wedemark", "Ravensberg", "Herford"],
+        "culture": "old_saxon"
+    },
+    "Winchester": {
+        "settlements": ["Southampton", "Portchester", "Carisbrooke", "Winchester", "St Swithun", "Wherwell", "Romsey", "Andover"],
+        "culture": "saxon"
+    },
+    "Mecklemburg": {
+        "settlements": ["Mecklemburg", "Parchim", "Lutzow", "Grevesmuhlen", "Gevezin", "Wismar", "Hagenow"],
+        "culture": "pommeranian"
+    },
+    "Hamburg": {
+        "settlements": ["Hamburg", "Altona", "Buxtehude", "Brunsbuttel", "Niendorf", "Lokstedt", "Dithmarschen"],
+        "culture": "old_saxon"
+    },
+    "Lubeck": {
+        "settlements": ["Ratzeburg", "Wulfsdorf", "Travemunde", "Starigard", "Schlutup", "Bucu", "Weslo", "Lubeck"],
+        "culture": "pommeranian"
+    },
+    "Holstein": {
+        "settlements": ["Itzehoe", "Reinholdsburg", "Lauenburg", "Kiel", "Elmshorn", "Segeberg"],
+        "culture": "old_saxon"
+    },
+    "Slesvig": {
+        "settlements": ["Aabenraa", "Haderslev", "Slesvig", "Ribe", "Flensborg", "Tonder", "Kolding", "Sonderborg", "Hedeby"],
+        "culture": "norse"
+    },
+    "Fyn": {
+        "settlements": ["Svendborg", "Kerteminde", "Odense", "Bogense", "Faaborg", "Middelfart", "Nyborg", "Assens"],
+        "culture": "norse"
+    },
+    "Sjaelland": {
+        "settlements": ["Kobenhavn", "Ringsted", "Kalundborg", "Naestved", "Vordingborg", "Slagelse", "Helsingor", "Roskilde"],
+        "culture": "norse"
+    },
+    "Jylland": {
+        "settlements": ["Aarhus", "Skive", "Ringkobing", "Jelling", "Randers", "Viborg", "Skagen", "Horsens", "Aalborg"],
+        "culture": "norse"
+    },
+    "Agder": {
+        "settlements": ["Holt", "Grimstad", "Flekkefjord", "Hylestad", "Sirdal", "Horga", "Visedal"],
+        "culture": "norse"
+    },
+    "Rogaland": {
+        "settlements": ["Hesby", "Stavanger", "Bygdeborg", "Jonegarden", "Naerbo", "Klepp", "Eikundarsund"],
+        "culture": "norse"
+    },
+    "Dorset": {
+        "settlements": ["Weymouth", "Wimborne", "Lyme", "Shaftesbury", "Dorchester", "Wareham", "Corfe", "Sherborne"],
+        "culture": "saxon"
+    },
+    "Telemark": {
+        "settlements": ["Fyresdal", "Eidsborg", "Hitterdals", "Gimsoy", "Fredriksten", "Skien", "Seljord", "Grenland"],
+        "culture": "norse"
+    },
+    "Vestfold": {
+        "settlements": ["Horten", "Nore", "Uvdal", "Re", "Tonsberg", "Skiringssal", "Arendall", "Kaupang"],
+        "culture": "norse"
+    },
+    "Akershus": {
+        "settlements": ["Bergheim", "Eidsvoll", "Baerum", "Jessheim", "Nes", "Akershus", "Isegran", "Oslo"],
+        "culture": "norse"
+    },
+    "Oppland": {
+        "settlements": ["Flesberg", "Lillehammer", "Dovre", "Slidre", "Garmo", "Favang", "Lom", "Oyer"],
+        "culture": "norse"
+    },
+    "Bergenshus": {
+        "settlements": ["Aurland", "Vik", "Bergen", "Hove", "Bergenhus", "Ask", "Fedje", "Kinsarvik"],
+        "culture": "norse"
+    },
+    "Trondelag": {
+        "settlements": ["Audunborg", "Austratt", "Sverresborg", "Trondheim", "Steinvikholm", "Borgund", "Nidaros"],
+        "culture": "norse"
+    },
+    "Hedmark": {
+        "settlements": ["Eidskog", "Kongsvinger", "Hamarhus", "Loten", "Hamar", "Vang", "Stange", "Elverum"],
+        "culture": "norse"
+    },
+    "Naumadal": {
+        "settlements": ["Hegra", "Logtun", "Halsstein", "Lade", "Levanger", "Tinghaugen", "Leksvik"],
+        "culture": "norse"
+    },
+    "Halogaland": {
+        "settlements": ["Hattfjelldalen", "Veiga", "Somna", "Bindal", "Lein", "Brunnoy", "Mosjoen", "Alstahaug"],
+        "culture": "norse"
+    },
+    "Lappi": {
+        "settlements": ["Giron", "Arjepluovvi", "Árviesjávrrie", "Jiellevárri", "Johkamohkki"],
+        "culture": "lappish"
+    },
+    "Norrbotten": {
+        "settlements": ["Bájil", "Biđona", "Bodena", "Gáinnasa", "Háhpáránddi", "Luleju", "Älvsbyna"],
+        "culture": "lappish"
+    },
+    "Somerset": {
+        "settlements": ["Muchelney", "Wells", "Ilchester", "Taunton", "Castle Cary", "Bath", "Cleeve", "Glastonbury"],
+        "culture": "saxon"
+    },
+    "Västerbotten": {
+        "settlements": ["Dorotea", "Lycksele", "Malå", "Suorssá", "Skielleta", "Storumana", "Vilhelmina", "Åsele", "Ubmi"],
+        "culture": "lappish"
+    },
+    "Angermanland": {
+        "settlements": ["Ulvo", "Natra"],
+        "culture": "norse"
+    },
+    "Jamtland": {
+        "settlements": ["Husan", "Mjalleborgen", "Vasterhus"],
+        "culture": "norse"
+    },
+    "Medelpad": {
+        "settlements": ["Selanger", "Alno", "Skon"],
+        "culture": "norse"
+    },
+    "Herjedalen": {
+        "settlements": ["Tannas", "Hogvalen", "Sveg"],
+        "culture": "norse"
+    },
+    "Halsingland": {
+        "settlements": ["Norrala", "Hog", "Jattendal"],
+        "culture": "norse"
+    },
+    "Gastrikland": {
+        "settlements": ["Valbo", "Hamrange", "Hedesunda", "Hille", "Farnebo"],
+        "culture": "norse"
+    },
+    "Dalarna": {
+        "settlements": ["Hedemora", "Borganas", "Kopparberg"],
+        "culture": "norse"
+    },
+    "Varmland": {
+        "settlements": ["Nordmark", "Josse", "Kil", "Arvika", "Gillberg", "Fryksdal", "Saxholm", "Vase"],
+        "culture": "norse"
+    },
+    "Vastmanland": {
+        "settlements": ["Koping", "Vasteras", "Kopingshus", "Arboga"],
+        "culture": "norse"
+    },
+    "Devon": {
+        "settlements": ["Axminster", "Tavistock", "Totnes", "Buckfast", "Exeter", "Lydford", "Crediton", "Dartmouth"],
+        "culture": "breton"
+    },
+    "Uppland": {
+        "settlements": ["Sigtuna", "Stockholm", "Alsno", "Enkoping", "Birka", "Hatuna", "Osteras", "Uppsala"],
+        "culture": "norse"
+    },
+    "Aland": {
+        "settlements": ["Sund", "Geta", "Kastelholm"],
+        "culture": "norse"
+    },
+    "Sodermanland": {
+        "settlements": ["Nykoping", "Vaderbrunn", "Hundhamra", "Eskilstuna", "Telge", "Torshalla", "Strangnas", "Gripsholm"],
+        "culture": "norse"
+    },
+    "Ostergotland": {
+        "settlements": ["Nasborg", "Stegeborg", "Jonkoping"],
+        "culture": "norse"
+    },
+    "Narke": {
+        "settlements": ["Hallsberg", "Kumla", "Orebro", "Mosas", "Goksholm"],
+        "culture": "norse"
+    },
+    "Dal": {
+        "settlements": ["Dalaborg"],
+        "culture": "norse"
+    },
+    "Viken": {
+        "settlements": ["Svenneby", "Kungahalla", "Svarteborg", "Bagahus"],
+        "culture": "norse"
+    },
+    "Vastergotland": {
+        "settlements": ["Husaby", "Galakvist", "Ymseborg", "Varnhem", "Lacko"],
+        "culture": "norse"
+    },
+    "Smaland": {
+        "settlements": ["Piksborg", "Vaxjo"],
+        "culture": "norse"
+    },
+    "Farrah": {
+        "settlements": ["Khakisafed", "Qalaikah", "Baladuluk", "Anardara", "Farrah", "Juwayn", "Shibkoh", "Bakwa"],
+        "culture": "afghan"
+    },
+    "Tyrconnell": {
+        "settlements": ["Gartan", "Ballyshannon", "Moville", "Fahan", "Kilmacrenan", "Raphoe", "Donegal", "Ballymacswiney"],
+        "culture": "irish"
+    },
+    "Worcester": {
+        "settlements": ["Worcester", "Pershore", "Kidderminster", "Laughern", "Malvern", "Evesham", "Droitwich", "Bromsgrove"],
+        "culture": "saxon"
+    },
+    "Oland": {
+        "settlements": ["Kopingsvik", "Ottenby", "Algutsrum", "Borgholm"],
+        "culture": "norse"
+    },
+    "Gotland": {
+        "settlements": ["Visborg", "Visby", "Slite", "Geatish Roma", "Othem"],
+        "culture": "norse"
+    },
+    "Halland": {
+        "settlements": ["Baastad", "Falkenberg", "Laholm", "Varberg", "Getinge", "Halmstad", "Aranaes", "Kungsbacka"],
+        "culture": "norse"
+    },
+    "Skane": {
+        "settlements": ["Uppakra", "Trelleborg", "Helsingborg", "Malmo", "Herrevad", "Lund", "Lillohus", "Ystad", "Dalby"],
+        "culture": "norse"
+    },
+    "Rugen": {
+        "settlements": ["Tribuzin", "Ralswiek", "Charenza", "Barth", "Rugard", "Hiddensee", "Putbus", "Arkona"],
+        "culture": "pommeranian"
+    },
+    "Bornholm": {
+        "settlements": ["Hammershus", "Ronne", "Aakirkeby", "Nexo", "Hasle", "Svaneke", "Knudsker", "Gudhjem"],
+        "culture": "norse"
+    },
+    "Rostock": {
+        "settlements": ["Ahrensberg", "Stargard", "Damgarten", "Malchin", "Gustrow", "Strelitz", "Penzlin", "Rostock"],
+        "culture": "pommeranian"
+    },
+    "Werle": {
+        "settlements": ["Demmin", "Greifswald", "Templin", "Stralsund", "Tribsees", "Treptow", "Waren", "Friedland"],
+        "culture": "pommeranian"
+    },
+    "Wolgast": {
+        "settlements": ["Ueckermunde", "Usedom", "Zinnowitz", "Kemnitz", "Zussow", "Wolgast", "Eggesin", "Anklam"],
+        "culture": "pommeranian"
+    },
+    "Altmark": {
+        "settlements": ["Walbeck", "Halberstedt", "Salzwedel", "Luchow", "Stendal", "Tangermunde", "Werben", "Osterburg"],
+        "culture": "old_saxon"
+    },
+    "Cornwall": {
+        "settlements": ["St Michael", "Liskeard", "Bodmin", "St Germans", "Truro", "Restormel", "Tintagel", "Launceston"],
+        "culture": "breton"
+    },
+    "Anhalt": {
+        "settlements": ["Magdeburg", "Arnstein", "Mansfeld", "Dessau", "Bernburg", "Zerbst", "Querfurt", "Haldensleben"],
+        "culture": "old_saxon"
+    },
+    "Plauen": {
+        "settlements": ["Halle", "Naumburg", "Zeitz", "Merseburg", "Leipzig", "Zwickau", "Knobelsdorf", "Plauen"],
+        "culture": "pommeranian"
+    },
+    "Meissen": {
+        "settlements": ["Wettin", "Dresden", "Strehla", "Meissen", "Belgern", "Dohna", "Radeburg", "Rabenau"],
+        "culture": "pommeranian"
+    },
+    "Bamberg": {
+        "settlements": ["Ansbach", "Babenberg", "Cadolzburg", "Crailsheim", "Colmberg", "Bamberg", "Roth", "Uffenheim"],
+        "culture": "german"
+    },
+    "Nurnberg": {
+        "settlements": ["Kulmbach", "Ellwangen", "Nordlingen", "Eichstatt", "Erlangen", "Furth", "Hohenburg", "Nurnberg"],
+        "culture": "german"
+    },
+    "Kempten": {
+        "settlements": ["Augsburg", "Hochstadt", "Rain", "Kaufbeuren", "Friedberg", "Zumarshausen", "Kempten", "Donauworth"],
+        "culture": "german"
+    },
+    "Tirol": {
+        "settlements": ["Ried", "Nenzing", "Sterzing", "Stanton", "Dornbirn", "Imst", "Bregenz", "Landeck"],
+        "culture": "german"
+    },
+    "Trent": {
+        "settlements": ["Bozen", "Meran", "Riva", "Brixen", "Rovereto", "Trento", "Schlanders"],
+        "culture": "lombard"
+    },
+    "Brescia": {
+        "settlements": ["Salo", "Lumezzane", "Montichiari", "Bergamo", "Brescia", "Castiglione", "Peschiera", "Treviglio"],
+        "culture": "lombard"
+    },
+    "Verona": {
+        "settlements": ["Barbarano", "Sanmartino", "Verona", "Montecchio", "Vicenza", "Schio", "Lonigo", "Arzignano"],
+        "culture": "lombard"
+    },
+    "Middlesex": {
+        "settlements": ["Staines", "Westminster", "Fulham", "Harrow", "Chelsea", "St Pauls", "London", "Tottenham"],
+        "culture": "saxon"
+    },
+    "Cremona": {
+        "settlements": ["Cremona", "Sospiro", "Casalmaggiore", "Castelgoffredo", "Manerbio", "Vescovato", "Crema", "Viadana"],
+        "culture": "lombard"
+    },
+    "Parma": {
+        "settlements": ["Noceto", "Massa", "Fontanellato", "Guastalla", "Laspezia", "Parma", "Fidenza", "Fornovo"],
+        "culture": "lombard"
+    },
+    "Modena": {
+        "settlements": ["Modena", "Sabbioneta", "Mirandola", "Novellara", "Carpi", "Sassuolo", "Reggionellemila", "Bomporto"],
+        "culture": "lombard"
+    },
+    "Lucca": {
+        "settlements": ["Viareggio", "Pistoia", "Seravezza", "Calcinaia", "Altopascio", "Capannori", "Cascina", "Lucca"],
+        "culture": "lombard"
+    },
+    "Corsica": {
+        "settlements": ["Alando", "Calvi", "Aleria", "Bastia", "Corte", "Morosaglia", "Luri", "Algajola"],
+        "culture": "italian"
+    },
+    "Arborea": {
+        "settlements": ["Sanluri", "Sorgono", "Tharros", "Oristano", "Cabras", "Santa Giusta", "Pabillonis", "Fordongianus"],
+        "culture": "italian"
+    },
+    "Cagliari": {
+        "settlements": ["Dolianova", "Capoterra", "Iglesias", "Assemini", "Carbonia", "Cagliari", "Santaigia"],
+        "culture": "italian"
+    },
+    "Pisa": {
+        "settlements": ["Canefro", "Livorno", "Pisa", "Volterra", "Vicopisano", "Portoferraio", "Sanminiato", "Giglio"],
+        "culture": "italian"
+    },
+    "Firenze": {
+        "settlements": ["Montevarchi", "Lucignano", "Sansepolcro", "Firenze", "Fiesole", "Prato", "Arezzo", "Certaldo"],
+        "culture": "italian"
+    },
+    "Urbino": {
+        "settlements": ["Gubbio", "Sanmarino", "Fano", "Cittadicastello", "Fossombrone", "Urbino", "Sanseverino", "Montefeltro"],
+        "culture": "italian"
+    },
+    "Faereyar": {
+        "settlements": ["Kvivik", "Funningur", "Skansin", "Kirkjubour", "Hov", "Klaksvik", "Torshavn", "Sandur"],
+        "culture": "pictish"
+    },
+    "Siena": {
+        "settlements": ["Siena", "Cortona", "Montalcino", "Montepulciano", "Monteriggioni", "Sangimignano", "Pienza"],
+        "culture": "italian"
+    },
+    "Piombino": {
+        "settlements": ["Piombino", "Radicofani", "Follonica", "Sanvincenzo", "Campiglia", "Barrati", "Populonia", "Suvereto"],
+        "culture": "italian"
+    },
+    "Orbetello": {
+        "settlements": ["Roselle", "Sorano", "Vetulonia", "Orbetello", "Sovana", "Rusellae", "Pitigliano", "Grosseto"],
+        "culture": "italian"
+    },
+    "Roma": {
+        "settlements": ["Tivoli", "Viterbo", "Tusculum", "Terracina", "Sutri", "Aragni", "Roma", "Ostia"],
+        "culture": "italian"
+    },
+    "Napoli": {
+        "settlements": ["Turris Octava", "Afragola", "Ischia", "Portici", "Cumae", "Aversa", "Napoli", "Pozzuoli"],
+        "culture": "greek"
+    },
+    "Benevento": {
+        "settlements": ["Avellino", "Conza", "Frigento", "Sanangelo", "Benevento", "Trevico", "Montemarono", "Ascoli"],
+        "culture": "lombard"
+    },
+    "Salerno": {
+        "settlements": ["Lucania", "Acerno", "Eboli", "Nocera", "Sarno", "Acenzera", "Salerno", "Agropoli"],
+        "culture": "lombard"
+    },
+    "Consenza": {
+        "settlements": ["Scalea", "Cerenzia", "Rossano", "Cosenza", "Argentano", "Strongoli", "Crotone"],
+        "culture": "greek"
+    },
+    "Reggio": {
+        "settlements": ["Gerace", "Bova", "Belcastro", "Nicotera", "Squillace", "Reggio", "Mileto", "Tropea"],
+        "culture": "greek"
+    },
+    "Messina": {
+        "settlements": ["Taormina", "Furnari", "Lipari", "Messina", "Sanmarcodalunzio", "Troinia", "Cataratti", "Torregrota"],
+        "culture": "greek"
+    },
+    "Shetland": {
+        "settlements": ["Yell", "Tingwall", "Cunningsburgh", "Sumburgh", "Scalloway", "Northmavine", "Sound", "Muness"],
+        "culture": "pictish"
+    },
+    "Palermo": {
+        "settlements": ["Palermo", "Monreale", "Misilmeri", "Petralia", "Caltavuturo", "Gratteri", "Mistretta"],
+        "culture": "greek"
+    },
+    "Trapani": {
+        "settlements": ["Mazara", "Alcarno", "Trapani", "Erice", "Marsala", "Castelvertrano"],
+        "culture": "greek"
+    },
+    "Agrigento": {
+        "settlements": ["Agricento", "Gela", "Licata", "Caltabellotta", "Butera", "Raffadali", "Montallegro"],
+        "culture": "greek"
+    },
+    "Siracusa": {
+        "settlements": ["Syracusa", "Paterno", "Caltagirone", "Augusta", "Centuripe", "Noto", "Lentini"],
+        "culture": "greek"
+    },
+    "Taranto": {
+        "settlements": ["Montepeloso", "Gravina", "Tricanico", "Mottola", "Castellaneta", "Taranto", "Cassano", "Tursi"],
+        "culture": "greek"
+    },
+    "Lecce": {
+        "settlements": ["Ligento", "Lecce", "Leuca", "Oria", "Castro", "Andrano", "Brindisi", "Otranto"],
+        "culture": "greek"
+    },
+    "Bari": {
+        "settlements": ["Bari", "Molietta", "Andria", "Giovinazzo", "Bitonto", "Conversano", "Ruvo", "Polignano"],
+        "culture": "lombard"
+    },
+    "Apulia": {
+        "settlements": ["Lucano", "Barletta", "Lavello", "Salapia", "Cannae", "Trani", "Melfi", "Minervo"],
+        "culture": "lombard"
+    },
+    "Foggia": {
+        "settlements": ["Bovino", "Termoli", "Vieste", "Siponto", "Salapla", "Foggia", "Lucera", "Troia"],
+        "culture": "lombard"
+    },
+    "Spoleto": {
+        "settlements": ["Assisi", "Todi", "Perugia", "Spoleto", "Nursia", "Valva"],
+        "culture": "lombard"
+    },
+    "Innse Gall": {
+        "settlements": ["Finlaggan", "Dunvegan", "Snizort", "Dunyveg", "Laggan", "Iona", "Uig", "Stornoway"],
+        "culture": "irish"
+    },
+    "Ancona": {
+        "settlements": ["Osimo", "Pesaro", "Recanati", "Fermo", "Ancona", "Rimini", "Matelica", "Camerino"],
+        "culture": "italian"
+    },
+    "Ravenna": {
+        "settlements": ["Ravenna", "Cesena", "Gatteo", "Alfonsine", "Cervia", "Cesenatico", "Gambettola", "Russi"],
+        "culture": "italian"
+    },
+    "Bologna": {
+        "settlements": ["Bentivoglio", "Bologna", "Forli", "Budno", "Bagnacavallo", "Castelguelfo", "Faenza", "Imola"],
+        "culture": "italian"
+    },
+    "Ferrara": {
+        "settlements": ["Bondeno", "Tresigallo", "Ferrara", "Codigoro", "Voghiera", "Occhiobello", "Commacchio", "Copparo"],
+        "culture": "italian"
+    },
+    "Mantua": {
+        "settlements": ["Virgilio", "Bagnolosanvito", "Gonzaga", "Serravalle", "Marmirolo", "Curtatone", "Mantua", "Castellucchio"],
+        "culture": "italian"
+    },
+    "Padova": {
+        "settlements": ["Vigonza", "Polesine", "Padova", "Este", "Rovigo", "Adria", "Montagnana", "Chioggia"],
+        "culture": "italian"
+    },
+    "Venezia": {
+        "settlements": ["Murano", "Torcello", "Jesolo", "Pallestrina", "Venezia", "Rialto", "Fusina", "Lido"],
+        "culture": "italian"
+    },
+    "Treviso": {
+        "settlements": ["Asola", "Oderzo", "Paese", "Ceneda", "Treviso", "Citadella", "Bassano", "Castelfranco"],
+        "culture": "lombard"
+    },
+    "Aquileia": {
+        "settlements": ["Friuli", "Aquileia", "Udine", "Motta", "Concordia", "Ciridale", "Sacile", "Portoguaro"],
+        "culture": "lombard"
+    },
+    "Innsbruck": {
+        "settlements": ["Kitzbuhel", "Schwaz", "Jenbach", "Kufstein", "Lienz", "Stams", "Innsbruck"],
+        "culture": "german"
+    },
+    "Orkney": {
+        "settlements": ["Wyre", "Sanday", "Ronaldsay", "Egilsay", "Birsay", "Orphir", "Kirkwall", "Westray"],
+        "culture": "pictish"
+    },
+    "Oberbayern": {
+        "settlements": ["Dingolfing", "Freising", "Ebersberg", "Diessen", "Pfaffenberg", "Andechs", "Munchen", "Dachau"],
+        "culture": "german"
+    },
+    "Niederbayern": {
+        "settlements": ["Kirchroth", "Cham", "Ingolstadt", "Landshut", "Rohrbach", "Regensburg", "Wittelsbach"],
+        "culture": "german"
+    },
+    "Domazlice": {
+        "settlements": ["Domazlice", "Kladruby", "Pisek", "Goldenkron", "Budejovice", "Rosenberg", "Hohenfurth", "Sobeslav"],
+        "culture": "bohemian"
+    },
+    "Litomerice": {
+        "settlements": ["Osek", "Ceskalipa", "Usti", "Zatec", "Duchcov", "Chomutov", "Kadan", "Jachymov"],
+        "culture": "bohemian"
+    },
+    "Lausitz": {
+        "settlements": ["Forst", "Cottbus", "Zittau", "Gorlitz", "Luckau", "Rothenburg", "Lebus"],
+        "culture": "pommeranian"
+    },
+    "Brandenburg": {
+        "settlements": ["Belzig", "Ruppin", "Havelberg", "Juterborg", "Brandenburg", "Berlin", "Muncheberg", "Oranienburg"],
+        "culture": "pommeranian"
+    },
+    "Stettin": {
+        "settlements": ["Kolbatz", "Soldin", "Wollin", "Kammin", "Pyritz", "Stettin", "Stestargard", "Cedene"],
+        "culture": "pommeranian"
+    },
+    "Slupsk": {
+        "settlements": ["Colberg", "Rugenwalde", "Schlawe", "Dramburg", "Slupsk", "Ustka", "Tempelburg", "Belgard"],
+        "culture": "pommeranian"
+    },
+    "Danzig": {
+        "settlements": ["Danlauenburg", "Mewe", "Schwetz", "Tuchel", "Schlochau", "Bytow", "Oliva", "Danzig"],
+        "culture": "pommeranian"
+    },
+    "Chelminskie": {
+        "settlements": ["Chelmno", "Thorn", "Eylau", "Briesen", "Lobau", "Niedenburg", "Rehden", "Kulm"],
+        "culture": "prussian"
+    },
+    "Caithness": {
+        "settlements": ["Dornoch", "Latheron", "Wick", "Dunbeath", "Freswick", "Thurso", "Golspie", "Dunrobin"],
+        "culture": "pictish"
+    },
+    "Marienburg": {
+        "settlements": ["Braunsberg", "Bartenstein", "Balga", "Christburg", "Marienburg", "Heilsberg", "Marienwerder", "Elbing"],
+        "culture": "prussian"
+    },
+    "Sambia": {
+        "settlements": ["Fischhausen", "Labiau", "Sambrandenburg", "Frombork", "Wiskiauten", "Cranz", "Konigsberg", "Tapiau"],
+        "culture": "prussian"
+    },
+    "Memel": {
+        "settlements": ["Dreverna", "Memel", "Juodkrante", "Kaup", "Palanga", "Nida", "Kretingale", "Gargzdai"],
+        "culture": "lithuanian"
+    },
+    "Kurs": {
+        "settlements": ["Duvzare", "Piltene", "Vanemane", "Ventava", "Ceklis", "Grobin", "Megava", "Bandava"],
+        "culture": "lettigallish"
+    },
+    "Zemigalians": {
+        "settlements": ["Selpils", "Cruczeborch", "Riga", "Remigala", "Jelgava", "Bauska", "Mezotne", "Skaistkalne"],
+        "culture": "lettigallish"
+    },
+    "Lettigalians": {
+        "settlements": ["Kokenois", "Lemisele", "Gaujiena", "Seswegen", "Wenden", "Wolmer", "Uxkull"],
+        "culture": "ugricbaltic"
+    },
+    "Osel": {
+        "settlements": ["Valjala", "Leisi", "Kaarma", "Muhu", "Poide", "Kuressare", "Hiiumaa", "Orisaare"],
+        "culture": "ugricbaltic"
+    },
+    "Livs": {
+        "settlements": ["Parnu", "Lihula", "Salaspils", "Haapsalu"],
+        "culture": "ugricbaltic"
+    },
+    "Reval": {
+        "settlements": ["Pades", "Toompea", "Leal", "Hapsal", "Laane", "Reval", "Borpeal", "Parnaw"],
+        "culture": "ugricbaltic"
+    },
+    "Dorpat": {
+        "settlements": ["Odenpah", "Kirrumpa", "Vastseliina", "Fellin", "Jarva", "Vanakastre", "Lais", "Tartu"],
+        "culture": "ugricbaltic"
+    },
+    "Teviotdale": {
+        "settlements": ["Maxwell", "Jedburgh", "Ednam", "Roxburgh", "Kelso", "Selkirk", "Peebles", "Melrose"],
+        "culture": "saxon"
+    },
+    "Narva": {
+        "settlements": ["Wesenberg", "Telsborg", "Alentagh", "Agelinde", "Repel", "Narva", "Pudiviru", "Askala"],
+        "culture": "ugricbaltic"
+    },
+    "Uusimaa": {
+        "settlements": ["Raasepori", "Hanko", "Lohja", "Porvoo", "Siuntio", "Espoo", "Helsinki", "Kirkkonummi", "Hyvinkää", "Järvenpää", "Karkkila", "Kauniainen", "Kerava", "Inkoo", "Vantaa", "Mäntsälä", "Askola", "Nurmijärvi", "Pornainen", "Sipoo", "Tuusula", "Vihti", "Loviisa"],
+        "culture": "finnish"
+    },
+    "Varsinais-Suomi": {
+        "settlements": ["Naantali", "Turku", "Jukarsborg", "Teinperi", "Rikala", "Lieto", "Kuusisto", "Salo", "Kaarina", "Raisio", "Loimaa", "Uusikaupunki", "Parainen", "Paimio", "Somero", "Masku", "Laitila", "Pöytyä", "Nousiainen"],
+        "culture": "finnish"
+    },
+    "Päijät-Häme": {
+        "settlements": ["Lahti", "Asikkala", "Hartola", "Heinola", "Hollola", "Orimattila", "Kärkölä", "Padasjoki", "Sysmä"],
+        "culture": "finnish"
+    },
+    "Kanta-Häme": {
+        "settlements": ["Forssa", "Hausjärvi", "Hämeenlinna", "Riihimäki", "Humppila", "Janakkala", "Jokioinen", "Hattula", "Loppi", "Tammela", "Ypäjä"],
+        "culture": "finnish"
+    },
+    "Keski-Suomi": {
+        "settlements": ["Jämsä", "Keuruu", "Saarijärvi", "Joutsa", "Kannonkoski", "Karstula", "Kinnula", "Kivijärvi", "Kuhmoinen", "Luhanka", "Multia", "Petäjävesi", "Pihtipudas", "Jyväskylä", "Viitasaari", "Äänekoski"],
+        "culture": "finnish"
+    },
+    "Satakunta": {
+        "settlements": ["Hahlo", "Kiukainen", "Kankaanpää", "Liinmaa", "Hiittenharju", "Pori", "Ulvila", "Telja", "Harjavalta", "Rauma", "Kokemäki", "Nakkila", "Eura", "Huittinen"],
+        "culture": "finnish"
+    },
+    "Pohjanmaa": {
+        "settlements": ["Kaskinen", "Kristiinankaupunki", "Pietarsaari", "Uusikaarlepyy", "Närpiö", "Vaasa", "Laihia", "Maalahti", "Isokyrö", "Luoto", "Vöyri"],
+        "culture": "finnish"
+    },
+    "Etelä-Pohjanmaa": {
+        "settlements": ["Alajärvi", "Alavus", "Kauhajoki", "Kauhava", "Kurikka", "Lapua", "Seinäjoki", "Ähtäri", "Soini", "Ilmajoki", "Evijärvi", "Vimpeli", "Teuva"],
+        "culture": "finnish"
+    },
+    "Keski-Pohjanmaa": {
+        "settlements": ["Halsua", "Kannus", "Kaustinen", "Kokkola", "Perho", "Toholampi", "Veteli"],
+        "culture": "finnish"
+    },
+    "Pohjois-Pohjanmaa": {
+        "settlements": ["Oulu", "Pudasjärvi", "Pyhäjärvi", "Haapajärvi", "Kalajoki", "Kuusamo", "Nivala", "Oulainen", "Raahe", "Ylivieska", "Utajärvi", "Sievi", "Ii", "Liminka", "Muhos", "Tyrnävä", "Hailuoto", "Siikalatva"],
+        "culture": "finnish"
+    },
+    "Kymenlaakso": {
+        "settlements": ["Hamina", "Kotka", "Kouvola", "Iitti", "Pyhtää", "Virolahti", "Miehikkälä"],
+        "culture": "finnish"
+    },
+    "Kainuu": {
+        "settlements": ["Kajaani", "Paltamo", "Puolanka", "Sotkamo", "Ristijärvi", "Kuhmo", "Suomussalmi", "Hyrynsalmi"],
+        "culture": "finnish"
+    },
+    "Pirkanmaa": {
+        "settlements": ["Akaa", "Ikaalinen", "Kangasala", "Mänttä-Vilppula", "Nokia", "Orivesi", "Parkano", "Sastamala", "Tampere", "Valkeakoski", "Virrat", "Ylöjärvi", "Vesilahti", "Lempäälä", "Pirkkala", "Hämeenkyrö"],
+        "culture": "finnish"
+    },
+    "Etelä-Savo": {
+        "settlements": ["Pieksämäki", "Savonlinna", "Mäntyharju", "Puumala", "Mikkeli", "Sulkava", "Heinävesi", "Olavinlinna", "Hirvensalmi"],
+        "culture": "finnish"
+    },
+    "Pohjois-Savo": {
+        "settlements": ["Kiuruvesi", "Kuopio", "Keitele", "Suonenjoki", "Iisalmi", "Varkaus", "Juankoski", "Rautavaara", "Vieremä"],
+        "culture": "finnish"
+    },
+    "Etelä-Karjala": {
+        "settlements": ["Lappeenranta", "Savitaipale", "Imatra", "Ruokolahti", "Parikkala", "Luumäki", "Taipalsaari", "Rautjärvi"],
+        "culture": "finnish"
+    },
+    "Pohjois-Karjala": {
+        "settlements": ["Joensuu", "Kitee", "Lieksa", "Nurmes", "Outokumpu", "Ilomantsi", "Rääkkylä", "Liperi"],
+        "culture": "finnish"
+    },
+    "Karjala": {
+        "settlements": ["Kalevala", "Suojärvi", "Louhi", "Sortavala", "Kemi", "Kostamus", "Kontupohja", "Pitkäranta"],
+        "culture": "finnish"
+    },
+    "Sápmi": {
+        "settlements": ["Njávdán", "Roavvenjárga", "Giemajávri", "Suovvaguoika", "Ohcejohka", "Anár", "Duortnus", "Soađegilli", "Pello", "Eanodat", "Giepma", "Gihttel", "Muoná"],
+        "culture": "lappish"
+    },
+    "Kola": {
+        "settlements": ["Jekanskoi", "Tre", "Pechenga", "Lovozero", "Waranger", "Molovskoi", "Mafelskoi"],
+        "culture": "not_lappish"
+    },
+    "Finnmárk": {
+        "settlements": ["Ákŋoluokta", "Álaheadju", "Báhcavuotna", "Bearalváhki", "Čáhcesuolu", "Davvesiida", "Davvinjárga", "Deatnu", "Fálesnuorri", "Gáŋgaviika", "Guovdageaidnu", "Hámmárfeasta", "Kárášjohka", "Láhppi", "Mátta-Várjjat", "Muosát", "Porsáŋgu", "Unjárga", "Várggát"],
+        "culture": "lappish"
+    },
+    "Romsa": {
+        "settlements": ["Báhccavuotna", "Beardu", "Bjarkøy", "Birgi", "Divrrát", "Doasku", "Gáivuotna", "Gálsa", "Giehtavuotna", "Hárštá", "Ivgu", "Ivvárstáđit", "Leaŋgáviika", "Loabát", "Málatvuopmi", "Návuotna", "Omasvuotna", "Ránáidsuolu", "Ráisa", "Ráisavuotna", "Rivttát", "Romsa", "Siellat", "Skiervá", "Skánit"],
+        "culture": "lappish"
+    },
+    "Ross": {
+        "settlements": ["Rosemarkie", "Cromarty", "Tain", "Dingwall", "Avoch", "Fortrose", "Applecross", "Fearn"],
+        "culture": "pictish"
+    },
+    "Nordland": {
+        "settlements": ["Narvik", "Kabelvag", "Bodo", "Rodoy", "Harstad", "Rost", "Andenes", "Beiarn"],
+        "culture": "norse"
+    },
+    "Käkisalmi": {
+        "settlements": ["Kaukola", "Raivola", "Antrea", "Räisälä", "Kuolemajärvi", "Koivisto", "Käkisalmi", "Terijoki"],
+        "culture": "finnish"
+    },
+    "Onega": {
+        "settlements": ["Ust-Onega", "Segezha", "Pryazha", "Aunus", "Petrozavodsk", "Pudoga", "Kondopoga"],
+        "culture": "not_finnish"
+    },
+    "Trans-Portage": {
+        "settlements": ["Nyandoma", "Konosha", "Plesetsk", "Obozerskiy", "Samoded", "Shenkursk", "Solovetsky"],
+        "culture": "not_finnish"
+    },
+    "North Dvina": {
+        "settlements": ["Solvychegodsk", "Antonievosiysky", "Archangelsk", "Usolsk", "Novokholmogory", "Koryazhma", "Nikolokorelski"],
+        "culture": "samoyed"
+    },
+    "Bjarmia": {
+        "settlements": ["Kamenka", "Mezen", "Kusnezowa", "Kimzha", "Pinega", "Lampozhnya", "Okulovsky"],
+        "culture": "samoyed"
+    },
+    "Samoyeds": {
+        "settlements": ["Sukhanikha", "Vizhas", "Chizha", "Tarasova", "Arkhipovo", "Yazhma", "Kiya"],
+        "culture": "samoyed"
+    },
+    "Ugra": {
+        "settlements": ["Yarega", "Vodnyy", "Kadzherom", "Nizhodes", "Sosnogorsk", "Vuktyl", "Voyvozh"],
+        "culture": "samoyed"
+    },
+    "Syrj": {
+        "settlements": ["Emva", "Pyras", "Yugydyag", "Ezhva", "Zheshart", "Mikun", "Sindor"],
+        "culture": "samoyed"
+    },
+    "Tyrone": {
+        "settlements": ["Derry", "Tullyhogue", "Omagh", "Coleraine", "Dungannon", "Maghera", "Dungiven", "Aileach"],
+        "culture": "irish"
+    },
+    "Moray": {
+        "settlements": ["Forres", "Kinloss", "Urquhart", "Inverness", "Lochindorb", "Cawdor", "Elgin", "Nairn"],
+        "culture": "pictish"
+    },
+    "Zyriane": {
+        "settlements": ["Lek", "Kukushtan", "Suksun", "Kordon", "Posad", "Gari", "Ergach"],
+        "culture": "samoyed"
+    },
+    "Hlynov": {
+        "settlements": ["Izkar", "Kambarka", "Mozjga", "Sarapul", "Egra", "Glazkar", "Wotka"],
+        "culture": "mordvin"
+    },
+    "Veliky Ustug": {
+        "settlements": ["Pinyug", "Maromitsa", "Gleden", "Oparino", "Podosinovets", "Krasavino", "Luza"],
+        "culture": "samoyed"
+    },
+    "Romny": {
+        "settlements": ["Ugol", "Vysokaya", "Bykovskaya", "Kholuy", "Vozhega", "Yuchka", "Marinskaya"],
+        "culture": "not_finnish"
+    },
+    "Zaozerye": {
+        "settlements": ["Nazankha", "Afoninskaya", "Bolshaya", "Konechnaya", "Borisovskaya", "Zarechnaya", "Pashuchikha", "Kharovsk"],
+        "culture": "not_finnish"
+    },
+    "Chud": {
+        "settlements": ["Zalese", "Zaytsevo", "Krbor", "Veldvor", "Chunlovka", "Krutayaosyp", "Kamchuga"],
+        "culture": "not_finnish"
+    },
+    "Vologda": {
+        "settlements": ["Motyn", "Bolshayamurga", "Dvinitsa", "Sokol", "Staroye", "Kadnikovskaya"],
+        "culture": "not_finnish"
+    },
+    "Kostroma": {
+        "settlements": ["Zavolzhsk", "Nerektha", "Kosmynino", "Nekrasoskoye", "Sudislavl", "Apraksino", "Plyos"],
+        "culture": "mordvin"
+    },
+    "Beloozero": {
+        "settlements": ["Fedosyevo", "Khoklovo", "Babayevo", "Glushkovo", "Kirillobelozersky", "Kinilov", "Kaduy"],
+        "culture": "not_finnish"
+    },
+    "Bezhetsky Verh": {
+        "settlements": ["Rameshki", "Obrosovo", "Bezhetsk", "Maksatikha", "Spasnakholmu", "Molokovo", "Sonkovo", "Kyasovagora"],
+        "culture": "ilmenian"
+    },
+    "Buchan": {
+        "settlements": ["Aberdeen", "Banff", "Kintore", "Ellon", "St Machar", "Inverurie", "Fyvie", "Deer"],
+        "culture": "pictish"
+    },
+    "Toropets": {
+        "settlements": ["Dno", "Valday", "Toropets", "Staryarussa", "Kresttsy", "Lychkovo", "Demyansk", "Shimsk"],
+        "culture": "ilmenian"
+    },
+    "Vodi": {
+        "settlements": ["Liivtsula", "Valaam", "Khotchino", "Ivanovskaya", "Nosok", "Nyen", "Jogopera", "Noteborg"],
+        "culture": "ugricbaltic"
+    },
+    "Torzhok": {
+        "settlements": ["Kingisepp", "Vistino", "Vassakara", "Yamskygorodok", "Shcheremenski", "Volosovo", "Komarovka", "Konnovo"],
+        "culture": "ilmenian"
+    },
+    "Pskov": {
+        "settlements": ["Pskov", "Pechory", "Dedovichi", "Svyatogorki", "Gdov", "Soltchi", "Ostrov", "Porkhov"],
+        "culture": "ugricbaltic"
+    },
+    "Novgorod": {
+        "settlements": ["Borovichi", "Okulovka", "Chudovo", "Boldorki", "Luga", "Pestovo", "Novgorod"],
+        "culture": "ilmenian"
+    },
+    "Velikiye Luki": {
+        "settlements": ["Bely", "Usvyaty", "Opochka", "Velikiyeluki", "Sebezh", "Nevel", "Staryatoropa", "Loknya"],
+        "culture": "ilmenian"
+    },
+    "West Dvina": {
+        "settlements": ["Ludza", "Balvi", "Varakjani", "Rezekne", "Erle", "Daugavpils", "Vilaka", "Jersika", "Kraslava", "Kreuzburg"],
+        "culture": "lettigallish"
+    },
+    "Vitebsk": {
+        "settlements": ["Stryzhava", "Drazdy", "Baroniki", "Vitebsk", "Ruba", "Liozno", "Haradok", "Sakolniki"],
+        "culture": "ilmenian"
+    },
+    "Orsha": {
+        "settlements": ["Kopys", "Orsha", "Sianno", "Talachyn", "Horki", "Larynouka", "Novolukomi"],
+        "culture": "ilmenian"
+    },
+    "Polotsk": {
+        "settlements": ["Polotsk", "Pastavy", "Miory", "Myadzel", "Dzisna", "Braslaw", "Rasony"],
+        "culture": "ilmenian"
+    },
+    "Strathearn": {
+        "settlements": ["Crieff", "Dunblane", "Doune", "Auchterarder", "Tullibardine", "Inchaffray", "Kenmore", "Madderty"],
+        "culture": "pictish"
+    },
+    "Aukshayts": {
+        "settlements": ["Kernave", "Kreva", "Kaunas", "Zirmunai", "Vilnius", "Utena", "Bralaus", "Lida"],
+        "culture": "lithuanian"
+    },
+    "Zhmud": {
+        "settlements": ["Raseiniai", "Kraziai", "Jurbarkas", "Panemune", "Taurage", "Upyte", "Varviai", "Joniskis"],
+        "culture": "lithuanian"
+    },
+    "Scalovia": {
+        "settlements": ["Jomsberg", "Jurgaiten", "Splitter", "Skomanten", "Strewa", "Ragnit", "Russ"],
+        "culture": "prussian"
+    },
+    "Sudovia": {
+        "settlements": ["Trakai", "Augustavas", "Seiniai", "Merkine", "Raiziai", "Suvalkai", "Hrodna", "Vilkaviskis"],
+        "culture": "lithuanian"
+    },
+    "Jacwiez": {
+        "settlements": ["Grodno", "Iuje", "Jacwiez", "Zirmuny", "Niasvizh", "Mir", "Slonim", "Novogrudok"],
+        "culture": "lithuanian"
+    },
+    "Podlasie": {
+        "settlements": ["Zambrow", "Lapy", "Lomza", "Krynki", "Sejny", "Drohiczyn", "Kolno", "Tykocin"],
+        "culture": "lithuanian"
+    },
+    "Yatvyagi": {
+        "settlements": ["Johannisburg", "Lyck", "Valkininkai", "Druskininkai", "Yatvarena", "Lotzen", "Eckersberg"],
+        "culture": "lithuanian"
+    },
+    "Galindia": {
+        "settlements": ["Treuburg", "Hohenstein", "Gilgenburg", "Angerburg", "Neidenburg", "Nikelshagen", "Wielbark", "Osterode"],
+        "culture": "prussian"
+    },
+    "Kujawy": {
+        "settlements": ["Bydgoszcz", "Inowroclaw", "Kruszwica", "Topolka", "Wlocawek", "Lubanie", "Radziejow", "Brzesckujawskie"],
+        "culture": "polish"
+    },
+    "Gnieznienskie": {
+        "settlements": ["Wyszo", "Znin", "Lekno", "Naklo", "Wagrowiec", "Pyzdry", "Giecz", "Gniezno"],
+        "culture": "polish"
+    },
+    "Gowrie": {
+        "settlements": ["Dundee", "Scone", "Errol", "Forteviot", "Perth", "Abernethy", "Dunkeld", "Clunie"],
+        "culture": "pictish"
+    },
+    "Lubusz": {
+        "settlements": ["Kostrzyn", "Mysliborz", "Cedynia", "Zielonagora", "Sulecin", "Lubusz", "Santok", "Pryzyce"],
+        "culture": "polish"
+    },
+    "Poznanskie": {
+        "settlements": ["Poznan", "Strarygrode", "Srem", "Obrzycko", "Zbaszyn", "Czarkow", "Drzen", "Miedryrzecz"],
+        "culture": "polish"
+    },
+    "Kaliskie": {
+        "settlements": ["Kalisz", "Jarocin", "Ostrowielkopolski", "Tureck", "Krotoszyn", "Rawick", "Pieszew", "Konin"],
+        "culture": "polish"
+    },
+    "Opole": {
+        "settlements": ["Czestochowa", "Opole", "Namyslow", "Strzelce", "Olezno", "Raciborz", "Lelow", "Kozle"],
+        "culture": "polish"
+    },
+    "Lower Silesia": {
+        "settlements": ["Krosno", "Jawor", "Legnica", "Glogow", "Boleslawiec", "Lwowek", "Swidnica"],
+        "culture": "polish"
+    },
+    "Upper Silesia": {
+        "settlements": ["Zmigrod", "Olesnica", "Nysa", "Wroclaw", "Brzeg", "Henrykow", "Niemcza", "Milicz"],
+        "culture": "polish"
+    },
+    "Boleslav": {
+        "settlements": ["Turnov", "Jaromer", "Trutnov", "Kamieniec", "Hradiste", "Jicin", "Glatz", "Nachod"],
+        "culture": "bohemian"
+    },
+    "Praha": {
+        "settlements": ["Karlstein", "Praha", "Kuttenberg", "Kolin", "Brevnov", "Stare Mesto", "Zbraslav", "Slany"],
+        "culture": "bohemian"
+    },
+    "Hradec": {
+        "settlements": ["Pardubice", "Zamberk", "Chrudim", "Hradeckralove", "Pelhrimov", "Policka", "Litomysl", "Jihlava"],
+        "culture": "bohemian"
+    },
+    "Plzen": {
+        "settlements": ["Tachov", "Susice", "Stribo", "Cheb", "Plasy", "Plzen", "Rokycany", "Pomuk"],
+        "culture": "bohemian"
+    },
+    "Atholl": {
+        "settlements": ["Pitlochry", "Fortingall", "Grandtully", "Anthrachs", "Strathardle", "Rannoch", "Glen Dochart", "Blair Atholl", "Struan"],
+        "culture": "pictish"
+    },
+    "Olomouc": {
+        "settlements": ["Ostrava", "Zdar", "Opava", "Unicov", "Olomouc", "Moravskatrebova", "Sternberk", "Zabreh"],
+        "culture": "bohemian"
+    },
+    "Brno": {
+        "settlements": ["Boskovice", "Kromeriz", "Uherskehradiste", "Velehrad", "Wisowitz", "Prerov", "Zlin", "Uherskebrod"],
+        "culture": "bohemian"
+    },
+    "Trencin": {
+        "settlements": ["Congsberg", "Puho", "Turoc", "Ban", "Illava", "Trencsen", "Povazskabystrica", "Zilina"],
+        "culture": "bohemian"
+    },
+    "Nitra": {
+        "settlements": ["Zabokreky", "Preuigan", "Galgoc", "Postyen", "Nagytapolcsany", "Nyitra", "Stbenedek", "Nagysurany"],
+        "culture": "bohemian"
+    },
+    "Esztergom": {
+        "settlements": ["Kakath", "Nagyigmand", "Nemesocsa", "Esztergom", "Komarom", "Gyorszentmarton", "Tatabanya", "Ogylla"],
+        "culture": "avar"
+    },
+    "Pressburg": {
+        "settlements": ["Szentgyorgy", "Pressburg", "Dunaszerdahely", "Somorja", "Nagyszombat", "Bazin", "Modor", "Galanta"],
+        "culture": "bohemian"
+    },
+    "Znojmo": {
+        "settlements": ["Eibenshitz", "Ivancice", "Mikulov", "Iglau", "Znojmo", "Trebic", "Lundenburg", "Skalitz"],
+        "culture": "bohemian"
+    },
+    "Passau": {
+        "settlements": ["Formbach", "Ortenburg", "Schaumberg", "Raab", "Freyung", "Passau", "Freistadt", "Ulrichsberg"],
+        "culture": "german"
+    },
+    "Salzburg": {
+        "settlements": ["Salzburg", "Durmberg", "Gastein", "Berchtesgaden", "Muhldorf", "Tittmoning", "Laufen", "Waging"],
+        "culture": "german"
+    },
+    "Osterreich": {
+        "settlements": ["Hohenwarth", "Wien", "Linz", "Melk", "Steyr", "Stpolten", "Krems", "Wagram"],
+        "culture": "german"
+    },
+    "Argyll": {
+        "settlements": ["Sween", "Argh", "Dunollie", "Loch Awe", "Kilmun", "Dunstaffnage", "Inverary", "St Moluag", "Ardchattan"],
+        "culture": "irish"
+    },
+    "Sopron": {
+        "settlements": ["Gyor", "Csepreg", "Sopron", "Nagymarton", "Csorna", "Borsmonostor", "Kismarton", "Kapuvar"],
+        "culture": "croatian"
+    },
+    "Fejer": {
+        "settlements": ["Adony", "Szekszard", "Val", "Dombovar", "Tamasi", "Sarbogard", "Bonyhad", "Mor"],
+        "culture": "avar"
+    },
+    "Pecs": {
+        "settlements": ["Kalocsa", "Szentlorinc", "Darda", "Pecsvarad", "Mohacs", "Sasd", "Pecs", "Siklos"],
+        "culture": "avar"
+    },
+    "Szekezfehervar": {
+        "settlements": ["Nagyatad", "Lengyeltoti", "Szigetvar", "Marcali", "Szekezfehervar", "Barcs", "Kaposvar", "Csurgo"],
+        "culture": "avar"
+    },
+    "Vas": {
+        "settlements": ["Nemetujvar", "Koszeg", "Szentgotthard", "Sarvar", "Kormend", "Celldomolk", "Szombathely", "Vasvar"],
+        "culture": "croatian"
+    },
+    "Steiermark": {
+        "settlements": ["Seckau", "Graz", "Lavant", "Leibnitz", "Radkersburg", "Stubing", "Cilli", "Eppenstein"],
+        "culture": "german"
+    },
+    "Karnten": {
+        "settlements": ["Laibach", "Villach", "Sann", "Treffen", "Klagenfurt", "Ossiach", "Pettau"],
+        "culture": "croatian"
+    },
+    "Krain": {
+        "settlements": ["Gorz", "Zerknitz", "Stveit", "Gurk", "Krainburg", "Guetenegg", "Auersperg", "Stain"],
+        "culture": "croatian"
+    },
+    "Istria": {
+        "settlements": ["Lovrana", "Mitterburg", "Trieste", "Pula", "Karstberg", "Wolauska", "Fiume", "Duino"],
+        "culture": "croatian"
+    },
+    "Veglia": {
+        "settlements": ["Crikvenica", "Bakar", "Krk", "Veglia", "Cres", "Kraljevica", "Vrbovsko", "Frankopan"],
+        "culture": "croatian"
+    },
+    "Fife": {
+        "settlements": ["Leuchars", "Kinross", "Cupar", "Lochore", "St Andrews", "Dunfermline", "Kirkcaldy", "Falkland"],
+        "culture": "pictish"
+    },
+    "Varadzin": {
+        "settlements": ["Ludbreg", "Krapina", "Oroslavje", "Varazdin", "Cakovec", "Donjastubica", "Lepoglava", "Toplice"],
+        "culture": "croatian"
+    },
+    "Zagreb": {
+        "settlements": ["Sisak", "Karlovac", "Zrin", "Zagreb", "Cetin", "Dreznik", "Ozalj"],
+        "culture": "croatian"
+    },
+    "Krizevci": {
+        "settlements": ["Koprivnica", "Durdevac", "Pozega", "Krizevci", "Vinkovci", "Vukovar", "Virovitica", "Osijek"],
+        "culture": "croatian"
+    },
+    "Usora": {
+        "settlements": ["Blagaj", "Usora", "Kuljc", "Banjaluka", "Jajce", "Bihac", "Bocac", "Prijedor"],
+        "culture": "croatian"
+    },
+    "Senj": {
+        "settlements": ["Udbina", "Karlobag", "Donjilapac", "Brinje", "Kaseg", "Otocac", "Senj"],
+        "culture": "croatian"
+    },
+    "Zadar": {
+        "settlements": ["Obrovac", "Sibenik", "Novigrad", "Knin", "Benkovac", "Nin", "Zadar", "Pag"],
+        "culture": "croatian"
+    },
+    "Zachlumia": {
+        "settlements": ["Sirokibrijeg", "Drvar", "Neretva", "Livno", "Ljubuski", "Mostar", "Capljina", "Duvno"],
+        "culture": "croatian"
+    },
+    "Split": {
+        "settlements": ["Trogir", "Split", "Klis", "Makarska", "Solin", "Imotski", "Sinj", "Hvar"],
+        "culture": "croatian"
+    },
+    "Ragusa": {
+        "settlements": ["Ragusa", "Cavtat", "Mljet", "Kolocep", "Slano", "Narona", "Sipan"],
+        "culture": "serbian"
+    },
+    "Zeta": {
+        "settlements": ["Bar", "Budva", "Danj", "Drivast", "Podgorica", "Ulcinj", "Skadar", "Kotor"],
+        "culture": "serbian"
+    },
+    "Clydesdale": {
+        "settlements": ["Cadzow", "Lesmahagow", "Lanark", "Bothwell", "St Kentigern", "Renfrew", "Dumbarton", "Glasgow"],
+        "culture": "welsh"
+    },
+    "Dyrrachion": {
+        "settlements": ["Chounavia", "Kruje", "Spinarizza", "Valona", "Durazzo", "Elbasan", "Beat", "Geziq"],
+        "culture": "greek"
+    },
+    "Ochrid": {
+        "settlements": ["Tomot", "Bitola", "Ohrid", "Krusevo", "Svetigrad", "Kicevo", "Debar", "Kastoria"],
+        "culture": "serbian"
+    },
+    "Epeiros": {
+        "settlements": ["Igoumenitsa", "Sagiada", "Sopot", "Paramythia", "Butrint", "Gjirokaster", "Ioannina", "Pogonia"],
+        "culture": "greek"
+    },
+    "Arta": {
+        "settlements": ["Angelokastron", "Preveza", "Thomokastron", "Vonitsza", "Arta", "Rogoi", "Vlacherna", "Agnanta"],
+        "culture": "greek"
+    },
+    "Cephalonia": {
+        "settlements": ["Zante", "Lefkas", "Ithaca", "Cerigo", "Palaiofrourio", "Paxos", "Kefalonia"],
+        "culture": "greek"
+    },
+    "Hellas": {
+        "settlements": ["Markrynia", "Amphissa", "Amfissa", "Lidoriki", "Kastrinitsi", "Paravola", "Naupaktos"],
+        "culture": "greek"
+    },
+    "Achaia": {
+        "settlements": ["Andravida", "Pyrgos", "Karditza", "Chalandritza", "Patras", "Akova", "Kalavryta", "Geraki"],
+        "culture": "greek"
+    },
+    "Methone": {
+        "settlements": ["Kiparissia", "Coron", "Kalamata", "Gritzena", "Karytaina", "Pilos", "Modon", "Androusa"],
+        "culture": "greek"
+    },
+    "Monemvasia": {
+        "settlements": ["Gythio", "Lacedaemonia", "Elos", "Monemvasia", "Mistra", "Arkadia", "Nikli", "Sparta"],
+        "culture": "greek"
+    },
+    "Kaneia": {
+        "settlements": ["Matala", "Nikiforosfokas", "Kastellikissamos", "Paleohora", "Arkadi", "Kandia", "Rethymno", "Akrotin"],
+        "culture": "greek"
+    },
+    "Lothian": {
+        "settlements": ["Linlithgow", "Torphichen", "Falkirk", "Edinburgh", "Leith", "Stirling", "Abercorn", "Stow Of Wedale"],
+        "culture": "welsh"
+    },
+    "Chandax": {
+        "settlements": ["Ierapetra", "Agiosnikolaos", "Knossos", "Kastelli", "Iraklio", "Sitia", "Malia", "Lassithi"],
+        "culture": "greek"
+    },
+    "Korinthos": {
+        "settlements": ["Corinth", "Veligosti", "Nauplion", "Vostitza", "Zemenos", "Megapoli", "Argos", "Passava"],
+        "culture": "greek"
+    },
+    "Atheniai": {
+        "settlements": ["Marathon", "Karydi", "Megara", "Athens", "Salamis", "Soula", "Daphni"],
+        "culture": "greek"
+    },
+    "Rhodos": {
+        "settlements": ["Karpathos", "Kos", "Ialysos", "Rhodos", "Lindos", "Pefkos", "Koskinou", "Haraki"],
+        "culture": "greek"
+    },
+    "Naxos": {
+        "settlements": ["Tinos", "Hermoupolis", "Mykonos", "Filoti", "Santorini", "Andros", "Naxos", "Kastraki"],
+        "culture": "greek"
+    },
+    "Euboia": {
+        "settlements": ["Istiaia", "Lilantia", "Messapia", "Kymi", "Chalkis", "Oreoi", "Artemisio", "Karystos"],
+        "culture": "greek"
+    },
+    "Chios": {
+        "settlements": ["Fourni", "Pagondas", "Marathokampos", "Chios", "Tigani", "Chrysostomos", "Samos", "Ikaria"],
+        "culture": "greek"
+    },
+    "Lesbos": {
+        "settlements": ["Agiasos", "Eresos", "Mytilene", "Kalloni", "Mithymna", "Moudros", "Thasos", "Plomari"],
+        "culture": "greek"
+    },
+    "Demetrias": {
+        "settlements": ["Gravia", "Ravennika", "Levadhia", "Boudonitza", "Neopatras", "Demetrias", "Lebadea", "Thebes"],
+        "culture": "greek"
+    },
+    "Thessalia": {
+        "settlements": ["Larissa", "Damasis", "Neopetra", "Trikkala", "Stagi", "Volos", "Kastri", "Pharsalos"],
+        "culture": "greek"
+    },
+    "Carrick": {
+        "settlements": ["Greenan", "Ballantrae", "Turnberry", "Loch Doon", "Culzean", "Crossraguel", "Maybole", "Dunure"],
+        "culture": "welsh"
+    },
+    "Thessalonike": {
+        "settlements": ["Hlerin", "Servia", "Thessaloniki", "Voden", "Elasson", "Cemren", "Veria"],
+        "culture": "greek"
+    },
+    "Chalkidike": {
+        "settlements": ["Melnik", "Mntathos", "Zicna", "Drama", "Chrysiopolis", "Philippi", "Serres", "Siderokastron"],
+        "culture": "greek"
+    },
+    "Strymon": {
+        "settlements": ["Kocane", "Strumica", "Trikves", "Prosek", "Kratovo", "Skopje", "Veles", "Prilep"],
+        "culture": "serbian"
+    },
+    "Philippopolis": {
+        "settlements": ["Anaktoropolis", "Klokoknitsa", "Peritheorion", "Polystylon", "Prodromos", "Mosynopolis", "Philippopolis", "Xantheia"],
+        "culture": "greek"
+    },
+    "Adrianopolis": {
+        "settlements": ["Traianopolis", "Berat", "Didymoteichon", "Ainos", "Kypsela", "Demotika", "Adrianopolis", "Skalothe"],
+        "culture": "greek"
+    },
+    "Kaliopolis": {
+        "settlements": ["Sestus", "Madyta", "Rhaidestos", "Gallipoli", "Lysimachia", "Panidos", "Selymbria", "Heraclea"],
+        "culture": "greek"
+    },
+    "Byzantion": {
+        "settlements": ["Galata", "Vlanga", "Pempton", "Blachernae", "Deuteron", "Hieron", "Constantinople", "Hagiasophia"],
+        "culture": "greek"
+    },
+    "Thrake": {
+        "settlements": ["Sestos", "Chariopolis", "Verissa", "Deleus", "Syrallum", "Aulaeitichus", "Phinopolis", "Salmydessus"],
+        "culture": "greek"
+    },
+    "Mesembria": {
+        "settlements": ["Mesembria", "Anchilios", "Sozopolis", "Aetos", "Odessos", "Varna", "Bourgas", "Valchidol"],
+        "culture": "bulgarian"
+    },
+    "Tyrnovo": {
+        "settlements": ["Irinopolis", "Opan", "Tyrnovo", "Maglizh", "Kazanlak", "Hisarya", "Chirpan", "Kilifarevski"],
+        "culture": "bulgarian"
+    },
+    "Ulster": {
+        "settlements": ["Dunluce", "Carrickfergus", "Downpatrick", "Bangor", "Connor", "Larne", "Dromore", "Dunseverick"],
+        "culture": "irish"
+    },
+    "Galloway": {
+        "settlements": ["Wigtown", "Threave", "Kirkcudbright", "Whithorn", "Dunragit", "Glenluce", "Dunrod", "Dumfries"],
+        "culture": "welsh"
+    },
+    "Serdica": {
+        "settlements": ["Velbazhd", "Rila", "Pravets", "Pernik", "Serdica", "Breznik", "Samundzhievo", "Etropole"],
+        "culture": "serbian"
+    },
+    "Naissus": {
+        "settlements": ["Knjazevac", "Kumanovo", "Vranje", "Nish", "Lesnovo", "Koprijan", "Brdo", "Kambelevac"],
+        "culture": "romanian"
+    },
+    "Rashka": {
+        "settlements": ["Polog", "Dioclea", "Trepca", "Zvecan", "Prizren", "Decani", "Svetispas", "Djakovica"],
+        "culture": "serbian"
+    },
+    "Hum": {
+        "settlements": ["Novipazar", "Pec", "Moraca", "Plav", "Stupovi", "Medun", "Bradarevo", "Belacrkva"],
+        "culture": "serbian"
+    },
+    "Rama": {
+        "settlements": ["Srebrenica", "Borac", "Srebrnik", "Zvornik", "Usice", "Samobor", "Zenica", "Rama"],
+        "culture": "serbian"
+    },
+    "Belgrade": {
+        "settlements": ["Branicevo", "Zemun", "Belgrade", "Lipovic", "Pozarevac", "Smederevo", "Rudnik", "Kragujevac"],
+        "culture": "serbian"
+    },
+    "Vidin": {
+        "settlements": ["Pirot", "Zajecar", "Kucevo", "Viseslav", "Kula", "Vidin", "Srvljig", "Bolvan"],
+        "culture": "romanian"
+    },
+    "Nikopolis": {
+        "settlements": ["Knezha", "Iskar", "Nikopolis", "Pleven", "Belene", "Oescus", "Dolnidabknik", "Pordim"],
+        "culture": "bulgarian"
+    },
+    "Dorostotum": {
+        "settlements": ["Slivopole", "Byaladve", "Tsenovo", "Dorosturum", "Samuil", "Shumen", "Rusi", "Borovo"],
+        "culture": "bulgarian"
+    },
+    "Karvuna": {
+        "settlements": ["Prezlav", "Varbitsz", "Kaliakra", "Venets", "Karvuna", "Silistria", "Smyadovo", "Dobrich"],
+        "culture": "bulgarian"
+    },
+    "Dunbar": {
+        "settlements": ["Berwick", "Coldingham", "Crichton", "Dunbar", "Tyninghame", "Huntly", "Thirlestane", "Gordon"],
+        "culture": "welsh"
+    },
+    "Constantia": {
+        "settlements": ["Cobadin", "Mesgidia", "Adamclisi", "Constantia", "Topraisar", "Cogealac", "Carachioi", "Mangalia"],
+        "culture": "bulgarian"
+    },
+    "Galaz": {
+        "settlements": ["Sulina", "Macin", "Galaz", "Vicina", "Isaccea", "Tulcea", "Crisan", "Aegyssus"],
+        "culture": "avar"
+    },
+    "Belgorod": {
+        "settlements": ["Chilia", "Palada", "Falciu", "Tigheci", "Oblucita", "Scheia", "Belgorod", "Oancea"],
+        "culture": "avar"
+    },
+    "Birlad": {
+        "settlements": ["Barlad", "Tecuci", "Vaslui", "Braila", "Galati", "Ramnicusarat", "Buzau"],
+        "culture": "avar"
+    },
+    "Turnu": {
+        "settlements": ["Bucuresti", "Giurgiu", "Rosiorriidevede", "Oltenita", "Turnu", "Dristra", "Corabia", "Strehaia"],
+        "culture": "avar"
+    },
+    "Tirgoviste": {
+        "settlements": ["Curteadearges", "Targoviste", "Ploiesti", "Calimanesti", "Campulung", "Poenari", "Pitesti", "Cotmeana"],
+        "culture": "avar"
+    },
+    "Severin": {
+        "settlements": ["Ursova", "Bals", "Slatina", "Craiova", "Ramnic", "Caracal", "Tirgujiu", "Severin"],
+        "culture": "romanian"
+    },
+    "Temes": {
+        "settlements": ["Versecz", "Lugos", "Detta", "Temesvar", "Buzias", "Csak", "Kevevara", "Karansebes"],
+        "culture": "avar"
+    },
+    "Bacs": {
+        "settlements": ["Apatin", "Pardany", "Zombor", "Szintarev", "Bacsalmas", "Bacs", "Baja", "Pancsova"],
+        "culture": "avar"
+    },
+    "Feher": {
+        "settlements": ["Feher", "Abrudbanya", "Vizakna", "Tovis", "Elek", "Gyulafehervar", "Nagyenyed", "Arad"],
+        "culture": "avar"
+    },
+    "Northumberland": {
+        "settlements": ["Norham", "Morpeth", "Alnwick", "Lindisfarne", "Mitford", "Newcastle", "Hexham", "Bamburgh"],
+        "culture": "saxon"
+    },
+    "Bihar": {
+        "settlements": ["Elesd", "Nagybajom", "Bihar", "Nagyvarad", "Debrecen", "Szalard", "Biharkeresztes", "Zolonta"],
+        "culture": "avar"
+    },
+    "Csanad": {
+        "settlements": ["Csongrad", "Battonya", "Hodmezovasarhely", "Mindszent", "Szentes", "Szeged", "Mako", "Csanad"],
+        "culture": "avar"
+    },
+    "Pest": {
+        "settlements": ["Kiskunhalas", "Kiskoros", "Kecskemet", "Cegled", "Vac", "Pest", "Szentendre", "Abrahamtelke"],
+        "culture": "avar"
+    },
+    "Heves": {
+        "settlements": ["Mezokovesd", "Hatvan", "Tiszafured", "Gyongyos", "Miskolc", "Heves", "Eger", "Petervasara"],
+        "culture": "avar"
+    },
+    "Gemer": {
+        "settlements": ["Jolsva", "Nyustya", "Losonc", "Rozsnyo", "Balassagyarmat", "Gomor", "Dobsina", "Nagyroce"],
+        "culture": "bohemian"
+    },
+    "Orava": {
+        "settlements": ["Nameszto", "Trsztena", "Arvavara", "Turdossin", "Rozsahegy", "Zolyom", "Nemetlipcse", "Liptovskymikulas"],
+        "culture": "bohemian"
+    },
+    "Cieszyn": {
+        "settlements": ["Oswiecim", "Zebrydowice", "Ustron", "Bielskobiala", "Jabloskow", "Cieszyn", "Goleszow", "Skoczow"],
+        "culture": "polish"
+    },
+    "Krakowskie": {
+        "settlements": ["Tarnow", "Kielce", "Chrzanow", "Skawina", "Brzesko", "Jedrzejow", "Olkusz", "Krakow"],
+        "culture": "polish"
+    },
+    "Sieradzko-Leczyckie": {
+        "settlements": ["Radomsko", "Wachock", "Blaski", "Sochaczew", "Warta", "Leczyka", "Sieradz", "Piotrkow"],
+        "culture": "polish"
+    },
+    "Plock": {
+        "settlements": ["Plock", "Wyszkow", "Ciechanow", "Warszawa", "Pultusk", "Pruszkow", "Plonsk", "Ostroleka"],
+        "culture": "polish"
+    },
+    "Cumberland": {
+        "settlements": ["Penrith", "Dacre", "Gilsland", "Papcastlet", "Carlisle", "Burgh", "Egremont", "Cockermouth"],
+        "culture": "saxon"
+    },
+    "Czersk": {
+        "settlements": ["Radom", "Siedlce", "Gorzno", "Grojec", "Borowie", "Losice", "Garwolin", "Czersk"],
+        "culture": "polish"
+    },
+    "Sandomierskie": {
+        "settlements": ["Wilczyce", "Samborzec", "Loniow", "Sandomierz", "Zawichost", "Koprzywnica", "Klimontow", "Dwikozy"],
+        "culture": "polish"
+    },
+    "Sacz": {
+        "settlements": ["Limanowa", "Gorlice", "Szczyrzycz", "Grybow", "Jasto", "Zakopane", "Nowysacz", "Brzozow"],
+        "culture": "polish"
+    },
+    "Saris": {
+        "settlements": ["Lemesany", "Giralth", "Saris", "Eperjes", "Kisszeben", "Scyuidnyk", "Bartfa", "Hethars"],
+        "culture": "croatian"
+    },
+    "Peremyshl": {
+        "settlements": ["Volkrosno", "Rzeszow", "Jaroslav", "Jaslo", "Sanok", "Peremyshl", "Grodek", "Lubaczow"],
+        "culture": "volhynian"
+    },
+    "Vladimir Volynsky": {
+        "settlements": ["Luboml", "Hrubieszow", "Kholm", "Torchyn", "Cherven", "Kovel", "Vladimirvolynsky", "Ivanichy"],
+        "culture": "volhynian"
+    },
+    "Galich": {
+        "settlements": ["Brody", "Dubno", "Vasyliv", "Galich", "Buzhsk", "Lvov", "Ternopil", "Kolomyia"],
+        "culture": "volhynian"
+    },
+    "Bereg": {
+        "settlements": ["Kapos", "Beregszasz", "Munkacs", "Szobranc", "Ungvar", "Szolyva", "Ilosva", "Perecseny"],
+        "culture": "croatian"
+    },
+    "Abauj": {
+        "settlements": ["Kassa", "Tokaj", "Szikszo", "Sarospatak", "Abauj", "Satoraljaujhely", "Szepsi", "Turna"],
+        "culture": "croatian"
+    },
+    "Marmaros": {
+        "settlements": ["Aknasugatag", "Felsoviso", "Maramarossziget", "Nagybanya", "Nagykaroly", "Tecso", "Huszt", "Raho"],
+        "culture": "avar"
+    },
+    "Isle Of Man": {
+        "settlements": ["Sulby", "Peel", "Kirk Michael", "Maughold", "Rushen", "Inis Patraic", "Laxey", "Douglas"],
+        "culture": "welsh"
+    },
+    "Szekelyfold": {
+        "settlements": ["Maros", "Szekelyudvarhely", "Csik", "Aranyos", "Kezdi", "Marosvasarhely", "Sepsiszentgyorgy", "Haromszek"],
+        "culture": "avar"
+    },
+    "Peresechen": {
+        "settlements": ["Varzaresti", "Baltile", "Iasi", "Harlau", "Chisinau", "Tutora", "Orhei", "Tuzara"],
+        "culture": "hungarian"
+    },
+    "Olvia": {
+        "settlements": ["Causeni", "Alibei", "Cainari", "Cetateaalba", "Tighina", "Ophusia", "Olvia", "Basarabeasca"],
+        "culture": "avar"
+    },
+    "Oleshye": {
+        "settlements": ["Balta", "Kocibey", "Odessa", "Sokoly", "Bohopol", "Akkerman", "Nikolayev", "Ochakiv"],
+        "culture": "hungarian"
+    },
+    "Korsun": {
+        "settlements": ["Zolotonosha", "Cherkassy", "Zhuravky", "Smila", "Uman", "Mirov", "Kaniv", "Korsun"],
+        "culture": "hungarian"
+    },
+    "Torki": {
+        "settlements": ["Suceava", "Torki", "Bogdana", "Cernauti", "Lipcani", "Siret", "Hotin"],
+        "culture": "volhynian"
+    },
+    "Terebovl": {
+        "settlements": ["Borschiv", "Kremenets", "Vinnytsia", "Terebovl", "Buchach", "Zalischyky", "Bratslav", "Pochayivlavra"],
+        "culture": "volhynian"
+    },
+    "Kiev": {
+        "settlements": ["Iskorosten", "Fastiv", "Yuriev", "Malyn", "Zhitomir", "Kiev", "Ovruch", "Vyshhorod"],
+        "culture": "volhynian"
+    },
+    "Pinsk": {
+        "settlements": ["Kosava", "Stepan", "Porkhovo", "Dabuchin", "Pinsk", "Biaroza", "Lutsk", "Luninets"],
+        "culture": "volhynian"
+    },
+    "Beresty": {
+        "settlements": ["Kobryn", "Lublin", "Bielsk", "Parczew", "Beresty", "Kamyanyets", "Wlodawa", "Mielnik"],
+        "culture": "volhynian"
+    },
+    "Westmorland": {
+        "settlements": ["Appleby", "Lowther", "Kirkby", "Brougham", "Shap", "Kendal", "Cartmel", "Brough"],
+        "culture": "saxon"
+    },
+    "Minsk": {
+        "settlements": ["Kapyl", "Kletsk", "Minsk", "Berezino", "Maladzyechna", "Valozhyn", "Borisow", "Nesvizh"],
+        "culture": "ilmenian"
+    },
+    "Mstislavl": {
+        "settlements": ["Chachersk", "Rahacou", "Chavusy", "Zhlobin", "Bychaw", "Mstitslavl", "Krychaw", "Mogilev"],
+        "culture": "severian"
+    },
+    "Turov": {
+        "settlements": ["Petrykaw", "Mazyr", "Turov", "Dubrovitsya", "Bobruisk", "Yelsk", "Slutsk", "Zhytkavichy"],
+        "culture": "volhynian"
+    },
+    "Lyubech": {
+        "settlements": ["Klimovo", "Loyew", "Lyubech", "Rechytsa", "Zlynka", "Novozybkov", "Brahin", "Gomel"],
+        "culture": "severian"
+    },
+    "Chernigov": {
+        "settlements": ["Nizhyn", "Kozelets", "Borzna", "Gorodets", "Mglin", "Sosnytsia", "Chernigov", "Horodnia"],
+        "culture": "severian"
+    },
+    "Pereyaslavl": {
+        "settlements": ["Hadyach", "Velykisorochyntsi", "Boryspil", "Chornukhy", "Lokhvytsia", "Pereyaslavl", "Hrebinka", "Myrhorod"],
+        "culture": "severian"
+    },
+    "Chortitza": {
+        "settlements": ["Khorol", "Lubny", "Ltava", "Baszmacka", "Alexandrowsk", "Rasumowka", "Vosnesjensk"],
+        "culture": "hungarian"
+    },
+    "Lukomorie": {
+        "settlements": ["Huliaipole", "Kushunum", "Kalchik", "Onkhiv", "Polohy", "Kalmius", "Chernihivka"],
+        "culture": "khazar"
+    },
+    "Lower Dniepr": {
+        "settlements": ["Tokmak", "Kyzylyar", "Pryazovske", "Shagingirei", "Bilozerka", "Kuturogly", "Kairy"],
+        "culture": "khazar"
+    },
+    "Crimea": {
+        "settlements": ["Kezlev", "Saq", "Qarasuvbazar", "Dzhankoy", "Aqmescit", "Qurman", "Perekop"],
+        "culture": "khazar"
+    },
+    "Durham": {
+        "settlements": ["Auckland", "Chester-Le-Street", "Raby", "Gateshead", "Jarrow", "St Cuthbert", "Durham", "Hartlepool"],
+        "culture": "saxon"
+    },
+    "Cherson": {
+        "settlements": ["Neapol", "Kerkinitis", "Kalamita", "Cembalo", "Charax", "Sevastoupolis", "Doros", "Kherson"],
+        "culture": "greek"
+    },
+    "Theodosia": {
+        "settlements": ["Caulita", "Funan", "Olyva", "Lusta", "Kimmerikon", "Soldaia", "Caffa", "Theodosia"],
+        "culture": "greek"
+    },
+    "Korchev": {
+        "settlements": ["Zavitne", "Vosporo", "Baherove", "Nymphaion", "Cherco", "Panticapea", "Chystopillia"],
+        "culture": "greek"
+    },
+    "Lower Don": {
+        "settlements": ["Latonovo", "Vesely", "Ryasnoye", "Matveevkurgan", "Novoazovsk", "Marfinka", "Skorokhod"],
+        "culture": "khazar"
+    },
+    "Desht-I-Kipchak": {
+        "settlements": ["Krasne", "Kramatorsk", "Lyman", "Mospyne", "Druzhkivka", "Dobropillia", "Sviatohirsk"],
+        "culture": "khazar"
+    },
+    "Sharukan": {
+        "settlements": ["Khorysdan", "Sumy", "Challykala", "Izyum", "Kupyansk", "Balakliia", "Lyubotin"],
+        "culture": "hungarian"
+    },
+    "Sugrov": {
+        "settlements": ["Khratayak", "Khursa", "Oboyan", "Tim", "Khazar", "Yauchy", "Fatezh"],
+        "culture": "hungarian"
+    },
+    "Novgorod Seversky": {
+        "settlements": ["Starodub", "Glukhov", "Putivl", "Trubchevsk", "Semenivka", "Rysk", "Novgorodseversky", "Sevsk"],
+        "culture": "severian"
+    },
+    "Smolensk": {
+        "settlements": ["Przhevalskoye", "Velizh", "Demidov", "Krasnoi", "Rodnya", "Yartsevo", "Smolensk"],
+        "culture": "ilmenian"
+    },
+    "Vyazma": {
+        "settlements": ["Dorogobuzh", "Vyazma", "Gzhatsky", "Dukhov", "Ugra", "Vyazkholm", "Safonovo", "Yelnya"],
+        "culture": "ilmenian"
+    },
+    "York": {
+        "settlements": ["York", "Skipton", "Conisbrough", "Pontefract", "Scarborough", "Richmond", "St Peters", "Hull"],
+        "culture": "saxon"
+    },
+    "Tver": {
+        "settlements": ["Vyshnyvolochyok", "Zubtsov", "Bezhichi", "Tver", "Udomelski", "Torzhok", "Tvergorodok", "Ostashkov"],
+        "culture": "ilmenian"
+    },
+    "Uglich": {
+        "settlements": ["Pertoma", "Kalyazin", "Tikhmenevo", "Kashin", "Myshkin", "Novynekouz", "Ustscheksna", "Uglich"],
+        "culture": "mordvin"
+    },
+    "Yaroslavl": {
+        "settlements": ["Timerevo", "Putyatino", "Yaroslavl", "Semibratovo", "Karabikha", "Volgostroy", "Romanov", "Tolga"],
+        "culture": "mordvin"
+    },
+    "Pereyaslavl Zalessky": {
+        "settlements": ["Pereyaslavlzalessky", "Sergiyevposad", "Karabanovo", "Kubrinsk", "Kupanskoye", "Aleksandrov", "Khmelniki", "Strunino"],
+        "culture": "mordvin"
+    },
+    "Rostov": {
+        "settlements": ["Spasoyakovlevsky", "Karash", "Rostov", "Gavrilovyam", "Sarskoyegorodishche", "Shurskol", "Borisoglebsky", "Petrovskoye"],
+        "culture": "mordvin"
+    },
+    "Moskva": {
+        "settlements": ["Serpukhov", "Belyov", "Kaluga", "Rzhev", "Klin", "Rogozhi", "Mozhaysk"],
+        "culture": "mordvin"
+    },
+    "Bryansk": {
+        "settlements": ["Mtsensk", "Dyatkovo", "Belev", "Karachev", "Klynov", "Orel", "Bryansk"],
+        "culture": "severian"
+    },
+    "Pronsk": {
+        "settlements": ["Tula", "Mikhaylov", "Bogoroditsk", "Yelets", "Ryazhsk", "Pronsk", "Skopin", "Sergijewskoje"],
+        "culture": "mordvin"
+    },
+    "Kolomna": {
+        "settlements": ["Kolomna", "Zaraysk", "Ramenskoye", "Bronnitsy", "Peski", "Egorevsk", "Cherkizovo", "Glukhovichi"],
+        "culture": "mordvin"
+    },
+    "Mordva": {
+        "settlements": ["Temnikow", "Yavas", "Ardatovo", "Krasnoslobodsk", "Yalga", "Insar", "Penza"],
+        "culture": "mordvin"
+    },
+    "Lancaster": {
+        "settlements": ["Gisburn", "Salford", "Bolton", "Furness", "Lancaster", "Clitheroe", "Sawley", "Preston"],
+        "culture": "saxon"
+    },
+    "Ryazan": {
+        "settlements": ["Klepiki", "Grodets", "Spassk", "Korablino", "Sasovo", "Solotcha", "Ryazan", "Rybnino"],
+        "culture": "mordvin"
+    },
+    "Murom": {
+        "settlements": ["Mordovshchikovo", "Vyksa", "Moramar", "Murom", "Lipnya", "Melenki", "Vilya", "Kulebaki"],
+        "culture": "mordvin"
+    },
+    "Vladimir": {
+        "settlements": ["Vladimir", "Petuschki", "Yuryevpolsky", "Sudogda", "Undol", "Volochok", "Sobinka", "Kosterevo"],
+        "culture": "mordvin"
+    },
+    "Suzdal": {
+        "settlements": ["Suzstarodub", "Suzivanovo", "Kovrov", "Lezhnevo", "Suzdal", "Bogolyubovo", "Seredaupino", "Teykovo"],
+        "culture": "mordvin"
+    },
+    "Nizhny Novgorod": {
+        "settlements": ["Balakhna", "Nizhnynovgorod", "Vasilyeva", "Sarov", "Knyaginino", "Kstovo", "Bor", "Bogorodsk"],
+        "culture": "mordvin"
+    },
+    "Gorodez": {
+        "settlements": ["Pravdinsk", "Puchishche", "Kitezh", "Sokolskoye", "Feodorovsky", "Gorkovskoye", "Lukh", "Gorodez"],
+        "culture": "mordvin"
+    },
+    "Galich Mersky": {
+        "settlements": ["Chistyebory", "Susanino", "Isaevo", "Galichmersky", "Buy", "Levkovo", "Gradmersky", "Kadyy"],
+        "culture": "mordvin"
+    },
+    "Mozhaysk": {
+        "settlements": ["Volgamozhaysk", "Shakhunya", "Uren", "Kiknur", "Vakhtan", "Tonshaevo", "Yaransk", "Varnavino"],
+        "culture": "mordvin"
+    },
+    "Merya": {
+        "settlements": ["Mariturek", "Morki", "Provoi", "Kilemary", "Lopatino", "Tsikma", "Volzhsk"],
+        "culture": "mordvin"
+    },
+    "Grassland Cheremisa": {
+        "settlements": ["Cistay", "Aznaqay", "Zay", "Bua", "Bawli", "Alabuga"],
+        "culture": "mordvin"
+    },
+    "Chester": {
+        "settlements": ["Sandbach", "Chester", "Nantwich", "Halton", "Malpas", "Northwich", "Macclesfield", "Beeston"],
+        "culture": "saxon"
+    },
+    "Chuvash": {
+        "settlements": ["Sundyr", "Alatyr", "Yadrin", "Kozlovka", "Tsivilsk", "Makaryevo", "Cheboksary"],
+        "culture": "mordvin"
+    },
+    "Mountain Cheremisa": {
+        "settlements": ["Kanadey", "Barysh", "Melekess", "Stanichnaya", "Vybornaya", "Butyrskaya", "Pokrovskoye"],
+        "culture": "mordvin"
+    },
+    "Burtasy": {
+        "settlements": ["Sosnovyostrov", "Mechetnaya", "Balakova", "Pokrovsk", "Atkarsk", "Rtishchevo", "Golykaramysh"],
+        "culture": "mordvin"
+    },
+    "Khopyor": {
+        "settlements": ["Ustmedveditskaya", "Uvarovo", "Kirsanov", "Uryupin", "Balashov", "Borisoglebsk"],
+        "culture": "mordvin"
+    },
+    "Sarkel": {
+        "settlements": ["Semikarakorsk", "Kazarki", "Belayavezha", "Ustdonetskiy", "Nizhchir", "Kotelnikovo", "Tsimlyanskoye"],
+        "culture": "khazar"
+    },
+    "Don Portage": {
+        "settlements": ["Ryumino", "Loq", "Donskoy", "Tary", "Illovlya", "Ozerki", "Illevka"],
+        "culture": "khazar"
+    },
+    "Tana": {
+        "settlements": ["Cherkassk", "Ustaksayaskaya", "Bataysk", "Monastyrsky", "Sulin", "Gundorovka", "Rostovnadonu"],
+        "culture": "khazar"
+    },
+    "Azov": {
+        "settlements": ["Kagalnik", "Sadki", "Azaq", "Eysk", "Kugey", "Akhtarsk", "Katon"],
+        "culture": "khazar"
+    },
+    "Tmutarakan": {
+        "settlements": ["Mapa", "Bata", "Tumnev", "Jevlisia", "Sujukqale", "Tsemes"],
+        "culture": "khazar"
+    },
+    "Kuban": {
+        "settlements": ["Podkumok", "Beshtau", "Kuban", "Psekups", "Coparia", "Kirpili"],
+        "culture": "khazar"
+    },
+    "Blekinge": {
+        "settlements": ["Lyckeby", "Elleholm", "Avaskar", "Lister", "Solvesborg Slott", "Lycka", "Ronneby", "Solvesborg"],
+        "culture": "norse"
+    },
+    "Perfeddwlad": {
+        "settlements": ["Llanelwy", "Denbigh", "Basingwerk", "Rhuddlan", "Flint", "Ruthin", "Ewloe", "Hawarden"],
+        "culture": "welsh"
+    },
+    "Abkhazia": {
+        "settlements": ["Bzyb", "Pitsunda", "Zugdidi", "Anakopia", "Tskhoumi", "Abaatha", "Egrisi", "Gagra"],
+        "culture": "georgian"
+    },
+    "Imeretia": {
+        "settlements": ["Geguti", "Kutaisi", "Bagrati", "Ghelati", "Tsikhegoji", "Lentekhi", "Motsameta", "Khoni"],
+        "culture": "georgian"
+    },
+    "Kasogs": {
+        "settlements": ["Zikh", "Koshkhab", "Bakhtarakhtar", "Sarytyuz", "Samiran", "Ustdzeghuta", "Eltarkan"],
+        "culture": "alan"
+    },
+    "Alania": {
+        "settlements": ["Magas", "Zaur", "Arkhyz", "Tkhabayerdy", "Tskhinval", "Tamarasheni", "Zadalesk"],
+        "culture": "alan"
+    },
+    "Kuma": {
+        "settlements": ["Kuliyurt", "Arslanbek", "Tereklimekteb", "Dylym", "Gums", "Babayurt", "Kizilyurt"],
+        "culture": "alan"
+    },
+    "Manych": {
+        "settlements": ["Kunay", "Nartkala", "Makhach", "Karabulak", "Terek", "Makhmudmekteb", "Malgobekbalka"],
+        "culture": "alan"
+    },
+    "Yegorlyk": {
+        "settlements": ["Yamki", "Kuguty", "Madjar", "Stauropolis", "Beshpagir", "Kiankiz", "Erkenshakhar"],
+        "culture": "alan"
+    },
+    "Sarpa": {
+        "settlements": ["Yashalta", "Ketchenery", "Ysaganaman", "Bachanta", "Karatchaplak", "Ikburul"],
+        "culture": "khazar"
+    },
+    "Lower Volga": {
+        "settlements": ["Prishib", "Serebrjakovo", "Dubovka", "Tsaritsyn", "Kamyshin", "Petrovval", "Kotovo"],
+        "culture": "khazar"
+    },
+    "Syrt": {
+        "settlements": ["Shungut", "Kinel", "Syzran", "Bandja", "Sarbay", "Osinki", "Tashia"],
+        "culture": "bolghar"
+    },
+    "Lincoln": {
+        "settlements": ["Lincoln", "Bardney", "Spalding", "Grantham", "Louth", "Gainsborough", "Stamford", "Boston"],
+        "culture": "saxon"
+    },
+    "Bulgar": {
+        "settlements": ["Tetyushi", "Arbuga", "Tawille", "Iq", "Suar", "Koshki", "Balimer"],
+        "culture": "bolghar"
+    },
+    "Qazan": {
+        "settlements": ["Pakli", "Usttuntor", "Pal", "Uymuzh", "Krmayak", "Belyaevka"],
+        "culture": "bolghar"
+    },
+    "Votyaki": {
+        "settlements": ["Bisert", "Ufimskiy", "Sarana", "Shamary", "Arti", "Shalya", "Atig"],
+        "culture": "komi"
+    },
+    "Bilyar": {
+        "settlements": ["Urussu", "Bryakhimov", "Bogulma", "Cukataw", "Dzhalil", "Tukhchin", "Nurlat"],
+        "culture": "bolghar"
+    },
+    "Ashli": {
+        "settlements": ["Janauyl", "Durtojle", "Blagovescen", "Yamantaw", "Boro", "Tuimasy", "Daulakan"],
+        "culture": "bolghar"
+    },
+    "Bashkirs": {
+        "settlements": ["Chishmy", "Sterlitamak", "Meleus", "Belebey", "Beloret", "Isembaj", "Bajmaq"],
+        "culture": "bolghar"
+    },
+    "Pecheneg": {
+        "settlements": ["Sadovy", "Saraktash", "Sakmara", "Kargala", "Khutorka", "Kichkas", "Tolkachi"],
+        "culture": "bolghar"
+    },
+    "Uzens": {
+        "settlements": ["Ushkuduk", "Aytbay", "Kyzylasker", "Krykuru", "Khasan", "Kosoba", "Akkus"],
+        "culture": "khazar"
+    },
+    "Guryev": {
+        "settlements": ["Birlik", "Besikty", "Yesmakan", "Sarayjuk", "Zhanakush", "Karabatyr", "Mantyube"],
+        "culture": "turkish"
+    },
+    "Saray": {
+        "settlements": ["Chernyyar", "Pokrovka", "Tsaganaman", "Dzhelga", "Bataevka", "Uspenka", "Saray"],
+        "culture": "khazar"
+    },
+    "Leicester": {
+        "settlements": ["Newark", "Hucknall", "Nottingham", "Southwell", "Leicester", "Newstead", "Tickhill", "Worksop"],
+        "culture": "saxon"
+    },
+    "Itil": {
+        "settlements": ["Tumak", "Kharabali", "Alga", "Khaganbaligh", "Saqsin", "Kamyzyak"],
+        "culture": "khazar"
+    },
+    "Kangly": {
+        "settlements": ["Makat", "Qulsary", "Akbulak", "Koshkar", "Bakachi", "Akkube", "Kizay"],
+        "culture": "turkish"
+    },
+    "Turkestan": {
+        "settlements": ["Aralkum", "Kosskul", "Emba", "Saksaulskiy", "Akespe", "Sapak", "Akshelek"],
+        "culture": "turkish"
+    },
+    "Aral": {
+        "settlements": ["Sokyrbulak", "Karakul", "Kuljandi", "Kaszkarata", "Aszczeatrik", "Dawletgirei", "Kosbulak"],
+        "culture": "turkish"
+    },
+    "Mangyshlak": {
+        "settlements": ["Amankyzylit", "Ashchimuryn", "Sayutes", "Uzen", "Kzyluzen", "Araldy", "Tigen"],
+        "culture": "turkish"
+    },
+    "Usturt": {
+        "settlements": ["Karamola", "Akkuduk", "Barsakelmos", "Bussaga", "Sumbe", "Sengirkum", "Aksu"],
+        "culture": "turkish"
+    },
+    "Khiva": {
+        "settlements": ["Kath", "Darvaza", "Sumanay", "Kuskupir", "Khiva", "Tahta", "Kizketken", "Atajab"],
+        "culture": "persian"
+    },
+    "Kara-Kum": {
+        "settlements": ["Yangadzha", "Kyzylsu", "Cheleken", "Dzhanga", "Ohk", "Awaza", "Bekdas", "Gazanjyk"],
+        "culture": "persian"
+    },
+    "Bukhara": {
+        "settlements": ["Chardjul", "Karkuh", "Kogon", "Gizhduvan", "Vabkent", "Ayrybaba", "Agar", "Bukhara"],
+        "culture": "sogdian"
+    },
+    "Konjikala": {
+        "settlements": ["Kyzylarvat", "Nisa", "Sarahs", "Farava", "Abiward", "Gokdepe", "Konjikala", "Ulugdepe"],
+        "culture": "persian"
+    },
+    "Derby": {
+        "settlements": ["Bakewell", "Wirksworth", "Burton", "Derby", "Chesterfield", "Repton", "Bolsover", "Castleton"],
+        "culture": "saxon"
+    },
+    "Merv": {
+        "settlements": ["Tagtabazar", "Yoloten", "Wekilbazar", "Bayramaly", "Gulanly", "Kushka", "Sakarcage", "Merv"],
+        "culture": "persian"
+    },
+    "Dihistan": {
+        "settlements": ["Gasankuli", "Kumdag", "Torskhali", "Yarymtyk", "Akhur", "Bayatkhadzi", "Yasydepe", "Kemir"],
+        "culture": "persian"
+    },
+    "Tus": {
+        "settlements": ["Bojnurd", "Mashhad", "Isfarayen", "Hasanabad", "Fagdatdezh", "Ghaisar", "Solak", "Shervan"],
+        "culture": "persian"
+    },
+    "Gurgan": {
+        "settlements": ["Ramian", "Komishdepa", "Minudasht", "Gurgan", "Aqqala", "Khanbebin", "Kordkuy", "Gonbadeqabus"],
+        "culture": "persian"
+    },
+    "Nishapur": {
+        "settlements": ["Shamat", "Daregaz", "Sabzevar", "Nishapur", "Chenaran", "Akhlamad", "Quchan", "Jajarm"],
+        "culture": "persian"
+    },
+    "Qohistan": {
+        "settlements": ["Torbatjam", "Mahvalat", "Beyhaq", "Gonabad", "Fariman", "Torshiz", "Kalat", "Bardaskan"],
+        "culture": "persian"
+    },
+    "Lut": {
+        "settlements": ["Aspak", "Kalateh", "Mazanabad", "Amanieh", "Tabas", "Esfandiar", "Dayhouk", "Bibaz"],
+        "culture": "persian"
+    },
+    "Sistan": {
+        "settlements": ["Zabol", "Nok Kundi", "Haozdar", "Dehak", "Esfandak", "Dozz Aap", "Kuh Taftan", "Shahresukhteh"],
+        "culture": "baloch"
+    },
+    "Yazd": {
+        "settlements": ["Taft", "Meybod", "Ardakan", "Zarch", "Chak Chak", "Nir", "Dar Anjir", "Yazd"],
+        "culture": "persian"
+    },
+    "Kerman": {
+        "settlements": ["Bardsir", "Ghaleganj", "Kerman", "Nough", "Behdesir", "Maymand", "Zarand"],
+        "culture": "persian"
+    },
+    "Gwynedd": {
+        "settlements": ["Degannwy", "Llanbadarn", "Conwy", "Cardigan", "Harlech", "Aberffraw", "Caernarfon", "Bangor Fawr"],
+        "culture": "welsh"
+    },
+    "Sirjan": {
+        "settlements": ["Dehbid", "Borougheeyeh", "Abarkuh", "Mehrabad", "Sirjan", "Faragheh", "Shahrbabak"],
+        "culture": "persian"
+    },
+    "Hormuz": {
+        "settlements": ["Kish", "Minab", "Gombroon", "Abarkawan", "Fin", "Bam", "Abu Musa", "Jiroth"],
+        "culture": "persian"
+    },
+    "Ladistan": {
+        "settlements": ["Lad", "Forg", "Bandarkhamir", "Khonj", "Evaz", "Bastak", "Jask", "Morbagh"],
+        "culture": "persian"
+    },
+    "Fars": {
+        "settlements": ["Khafr", "Lamerd", "Perozabad", "Gerash", "Kakhesasan", "Jahrom", "Estahbanat", "Darab"],
+        "culture": "persian"
+    },
+    "Shiraz": {
+        "settlements": ["Shiraz", "Estakhr", "Abadeh", "Bishapur", "Persepolis", "Arsanjan", "Bavanat", "Azargarta"],
+        "culture": "persian"
+    },
+    "Hendjan": {
+        "settlements": ["Behbahan", "Omidiyeh", "Argan", "Ramhormoz", "Susa", "Bandarshahpur", "Jayzan", "Bandaremashoor"],
+        "culture": "persian"
+    },
+    "Esfahan": {
+        "settlements": ["Sedeh", "Khansar", "Esfahan", "Abyaneh", "Kashan", "Ardestan", "Qomsheh", "Zarrinshahr"],
+        "culture": "persian"
+    },
+    "Avhaz": {
+        "settlements": ["Dezful", "Helen", "Farsan", "Shushtar", "Shahrekord", "Idhaj", "Koohrang", "Masjedsoleyman"],
+        "culture": "persian"
+    },
+    "Khozistan": {
+        "settlements": ["Dora", "Ahvaz", "Abadan", "Shadegan", "Hoveizeh", "Fao", "Izaj", "Khorramshahr"],
+        "culture": "persian"
+    },
+    "Basra": {
+        "settlements": ["Kalaatderat", "Qurna", "Basra", "Ummqasr", "Arah", "Mohammera", "Azzubayr", "Sukelsheyuhk"],
+        "culture": "bedouin_arabic"
+    },
+    "Powys": {
+        "settlements": ["Llandinam", "Montgomery", "Radnor", "Rhayader", "Llangollen", "Caersws", "Mathrafal", "Glascwm"],
+        "culture": "welsh"
+    },
+    "Kuwait": {
+        "settlements": ["Anthemusias", "Ashshuaybah", "Falalheel", "Alwafra", "Kuwait", "Arrawdatayn", "Ikaros", "Khinan"],
+        "culture": "bedouin_arabic"
+    },
+    "Damman": {
+        "settlements": ["Avan", "Najmah", "Abuhadriya", "Hinnah", "Qatif", "Jubail", "Alaba"],
+        "culture": "bedouin_arabic"
+    },
+    "Al Hasa": {
+        "settlements": ["Mubarraz", "Foda", "Omran", "Oyoon", "Ghunan", "Khobar", "Holuf", "Abqaiq", "Alhasa"],
+        "culture": "bedouin_arabic"
+    },
+    "Bahrein": {
+        "settlements": ["Al Masqar", "Umm As Sabaan", "Sitra", "Murwab", "Batn Ardasir", "Jidda", "Hamala", "Aldur"],
+        "culture": "bedouin_arabic"
+    },
+    "Rummah": {
+        "settlements": ["Hafaralbatin", "Samoudah", "Altheebiyah", "Arraqai", "Assuayerah", "Assufayri", "Qaisumah", "Alqalt"],
+        "culture": "bedouin_arabic"
+    },
+    "Kufa": {
+        "settlements": ["Shuyukh", "Chibayish", "Hammar", "Ragai", "Suqash", "Kufa", "Qurnah", "Bussayyah"],
+        "culture": "bedouin_arabic"
+    },
+    "Tigris": {
+        "settlements": ["Warka", "Qalatsjergat", "Ishan", "Nuffar", "Tellelhiba", "Majaralkabir", "Bismaya", "Samawah"],
+        "culture": "kurdish"
+    },
+    "Luristan": {
+        "settlements": ["Koohdasht", "Poledokhtar", "Dezbar", "Khorramabad", "Dorood", "Borujerd", "Aligoodarz", "Alashtar"],
+        "culture": "persian"
+    },
+    "Hamadan": {
+        "settlements": ["Ganjnameh", "Kabudrahang", "Ecbatana", "Asadabad", "Roudavar", "Nahavand", "Hamadan", "Malayer"],
+        "culture": "persian"
+    },
+    "Qom": {
+        "settlements": ["Jafariyeh", "Salafchegan", "Dastjerd", "Qanavat", "Kahak", "Qom", "Jamkaran", "Khourabad"],
+        "culture": "persian"
+    },
+    "Shrewsbury": {
+        "settlements": ["Clun", "Ludlow", "Chirk", "Oswestry", "Bridgnorth", "Wenlock", "Whitchurch", "Shrewsbury"],
+        "culture": "welsh"
+    },
+    "Qwivir": {
+        "settlements": ["Damqan", "Semnan", "Sharequmis", "Gerdkuh", "Darvar", "Kohandej", "Dehnamak", "Sangsar"],
+        "culture": "persian"
+    },
+    "Tabaristan": {
+        "settlements": ["Sari", "Farim", "Lavij", "Firuzkuh", "Rarem", "Mamatir", "Chamnoo", "Amul"],
+        "culture": "persian"
+    },
+    "Alamut": {
+        "settlements": ["Rostamrood", "Alamut", "Garmsar", "Varamin", "Chaloos", "Kalar", "Damavand", "Sisangan", "Kojoor"],
+        "culture": "persian"
+    },
+    "Rayy": {
+        "settlements": ["Hashtgerd", "Shahriar", "Eslamshahr", "Tehran", "Pakdasht", "Rayy", "Karaj"],
+        "culture": "persian"
+    },
+    "Qazwin": {
+        "settlements": ["Qazwin", "Buinzahra", "Takestan", "Alvand", "Avaj", "Ahmadabad", "Lambsar", "Abeyek"],
+        "culture": "persian"
+    },
+    "Daylam": {
+        "settlements": ["Khunaj", "Alamut", "Mahneshan", "Soltaniyeh", "Gheydar", "Tarom", "Zanjan"],
+        "culture": "persian"
+    },
+    "Gilan": {
+        "settlements": ["Talysh", "Rudbar", "Masouleh", "Rudkhan", "Astara", "Gilan", "Lahijan"],
+        "culture": "persian"
+    },
+    "Tabriz": {
+        "settlements": ["Sarab", "Shabestar", "Babak", "Ahar", "Tabriz", "Dihnakhirjan", "Zahhak"],
+        "culture": "kurdish"
+    },
+    "Shirvan": {
+        "settlements": ["Baku", "Absheron", "Salyan", "Altiagay", "Shirvan", "Khizirzinda", "Lankaran"],
+        "culture": "persian"
+    },
+    "Shemakha": {
+        "settlements": ["Khachmaz", "Ahemakha", "Anig", "Shikhlar", "Maraza", "Khil", "Quba", "Chiraggala"],
+        "culture": "persian"
+    },
+    "Warwick": {
+        "settlements": ["Dudley", "Tamworth", "Stafford", "Kenilworth", "Coventry", "Tutbury", "Lichfield", "Warwick"],
+        "culture": "saxon"
+    },
+    "Azerbaijan": {
+        "settlements": ["Kapalak", "Kalaberd", "Urmiah", "Takhtesuleiman", "Bastam", "Deglane", "Chaldoran"],
+        "culture": "armenian"
+    },
+    "Suenik": {
+        "settlements": ["Gandzassar", "Prochabert", "Goris", "Ghapan", "Areni", "Tatev", "Vorotnavank", "Noravank"],
+        "culture": "armenian"
+    },
+    "Dwin": {
+        "settlements": ["Khorvirap", "Erebuni", "Alaverdi", "Etchmiadzin", "Matsnaberd", "Sanahin", "Dvin"],
+        "culture": "armenian"
+    },
+    "Albania": {
+        "settlements": ["Shaki", "Chukhurkabala", "Gelersengorersen", "Kabala", "Barda", "Ganja", "Darussoltan", "Emli"],
+        "culture": "armenian"
+    },
+    "Derbent": {
+        "settlements": ["Narinkala", "Juma", "Kuli", "Humraj", "Tayus", "Chikkulkan", "Derbent", "Datuna"],
+        "culture": "armenian"
+    },
+    "Semender": {
+        "settlements": ["Burgaikala", "Tarki", "Urtseki", "Khannalkala", "Balanjar", "Semender", "Khattibaku", "Kumukh"],
+        "culture": "alan"
+    },
+    "Kakheti": {
+        "settlements": ["Telavi", "Bochorma", "Zedazaden", "Bodbe", "Gremi", "Dzveligalavani", "Davidgareja", "Sighnaghi"],
+        "culture": "georgian"
+    },
+    "Guria": {
+        "settlements": ["Khula", "Bukistsikhe", "Ozurgeti", "Udabno", "Tsikhisdziri", "Skhalta", "Batum", "Gonio"],
+        "culture": "georgian"
+    },
+    "Trapezous": {
+        "settlements": ["Rizaion", "Alucra", "Paiperta", "Rizini", "Koralla", "Dereli", "Kelkit", "Trapezous"],
+        "culture": "greek"
+    },
+    "Kartli": {
+        "settlements": ["Mtskheta", "Narikala", "Bebristsikhe", "Tbilisi", "Svetitskhoveli", "Djvari", "Sioni"],
+        "culture": "georgian"
+    },
+    "Northampton": {
+        "settlements": ["Ramsey", "Crowland", "Kettering", "Cambridge", "Rockingham", "Huntingdon", "Peterborough", "Northampton"],
+        "culture": "saxon"
+    },
+    "Tao": {
+        "settlements": ["Khakhuli", "Vardzia", "Oshki", "Akhaltsikhe", "Khertvisi", "Ughtik", "Panaskerti", "Artanuji"],
+        "culture": "georgian"
+    },
+    "Ani": {
+        "settlements": ["Karuts", "Artashat", "Surpasdvadzadzin", "Midjnaberd", "Oshakan", "Ani", "Zvartnots", "Karutsberd"],
+        "culture": "armenian"
+    },
+    "Vaspurakan": {
+        "settlements": ["Hadamakert", "Van", "Aghtamar", "Varagavank", "Vostan", "Bakear", "Surbkhach", "Haykaberd"],
+        "culture": "armenian"
+    },
+    "Amida": {
+        "settlements": ["Amida", "Ulucamii", "Mayyafarikin", "Suraamede", "Egil", "Kiaburc", "Hazretisuleymancamii", "Idtodyolataloho"],
+        "culture": "kurdish"
+    },
+    "Nisibin": {
+        "settlements": ["Nusaybin", "Sittiradviyyemadrasa", "Kerburan", "Dayrodmorgabriel", "Savur", "Cizre", "Yaqobnsibnaya", "Dairodmorhannanyo"],
+        "culture": "kurdish"
+    },
+    "Oromieh": {
+        "settlements": ["Takhtesoleyman", "Khoy", "Chaldiran", "Charekelisa", "Avajiq", "Mahabad", "Oroumieh", "Salmas"],
+        "culture": "kurdish"
+    },
+    "Kurdistan": {
+        "settlements": ["Dawodiya", "Dehi", "Duhok", "Marqayoma", "Bebadi", "Harmashi", "Sarsink", "Araden"],
+        "culture": "kurdish"
+    },
+    "Kirkuk": {
+        "settlements": ["Kifri", "Daquq", "Halabja", "Chuartan", "Makhmur", "Dukan", "Kirkuk", "Ranya"],
+        "culture": "kurdish"
+    },
+    "Kermanshah": {
+        "settlements": ["Kangavar", "Kuzaran", "Hulwan", "Paveh", "Javanroud", "Mahalkufa", "Kermanshah", "Ravansar"],
+        "culture": "kurdish"
+    },
+    "Ilam": {
+        "settlements": ["Abdanan", "Ghalehghiran", "Chahartaghi", "Mehran", "Towhid", "Ilam", "Hezardar", "Dehloran"],
+        "culture": "kurdish"
+    },
+    "Bedford": {
+        "settlements": ["Luton", "Bedford", "Hertford", "Berkhamsted", "Ashridge", "Dunstable", "Watford", "St Albans"],
+        "culture": "saxon"
+    },
+    "Al Amarah": {
+        "settlements": ["Suwaira", "Amarah", "Hai", "Badra", "Zurbatiyah", "Kutelamara", "Wasit", "Azeeziaya"],
+        "culture": "levantine_arabic"
+    },
+    "Al Nasiryah": {
+        "settlements": ["Nasiryah", "Muntafiq", "Dhiqar", "Qalatsukkar", "Shahrain", "Telloh", "Shatra", "Mukayyar"],
+        "culture": "levantine_arabic"
+    },
+    "Istakhr": {
+        "settlements": ["Kamin", "Iqlid", "Abarquh", "Abadha", "Istakhr", "Main", "Sarmaq"],
+        "culture": "persian"
+    },
+    "Al Nadjaf": {
+        "settlements": ["Jasim", "Jaarah", "Nadjaf", "Midhrawi", "Rahbah", "Kufah", "Taqtaqanah", "Rashid"],
+        "culture": "levantine_arabic"
+    },
+    "Baghdad": {
+        "settlements": ["Baqubah", "Latifiya", "Babel", "Madain", "Iskandariya", "Hillah", "Taji"],
+        "culture": "levantine_arabic"
+    },
+    "Karbala": {
+        "settlements": ["Ofak", "Hindiya", "Ukhaidir", "Hamzah", "Ainaltamur", "Qisair", "Shamiyah", "Karbala"],
+        "culture": "levantine_arabic"
+    },
+    "Deir": {
+        "settlements": ["Hit", "Rutbah", "Kasra", "Anbar", "Takrit", "Ramadi", "Rawa", "Nehardea"],
+        "culture": "assyrian"
+    },
+    "Euphrates": {
+        "settlements": ["Tagrit", "Amirli", "Faris", "Samarra", "Dujail", "Balad", "Ishaqi", "Bayji"],
+        "culture": "assyrian"
+    },
+    "Mosul": {
+        "settlements": ["Aqrah", "Bartella", "Bakhdida", "Baqofah", "Mosul", "Arbil", "Shekhan"],
+        "culture": "assyrian"
+    },
+    "Al Jazira": {
+        "settlements": ["Hamoukar", "Dayrik", "Amuda", "Dakhiliyah", "Darbasiyah", "Hasakah", "Qamishhlo", "Teltamer"],
+        "culture": "levantine_arabic"
+    },
+    "Edessa": {
+        "settlements": ["Sruk", "Kaisun", "Edesurfa", "Samsat", "Bile", "Tulupe", "Harran", "Edessa"],
+        "culture": "armenian"
+    },
+    "Oriel": {
+        "settlements": ["Clones", "Clogher", "Drogheda", "Armagh", "Monaghan", "Olouth", "Dundalk", "Ardee"],
+        "culture": "irish"
+    },
+    "Norfolk": {
+        "settlements": ["Chatteris", "Norwich", "Thetford", "Lynn", "Yarmouth", "Elmham", "Buckenham", "Castle Rising"],
+        "culture": "saxon"
+    },
+    "Bira": {
+        "settlements": ["Bira", "Resaina", "Samrah", "Derik", "Qoser", "Stewr", "Tella", "Qalarebete"],
+        "culture": "kurdish"
+    },
+    "Taron": {
+        "settlements": ["Arakelots", "Mush", "Akhlat", "Sason", "Manzikert", "Glak", "Artchesh", "Ararati"],
+        "culture": "armenian"
+    },
+    "Mesopotamia": {
+        "settlements": ["Martyropolis", "Tzimisca", "Tigranakert", "Mayafaraqin", "Jermuk", "Arghana", "Lice", "Hani"],
+        "culture": "armenian"
+    },
+    "Karin": {
+        "settlements": ["Kirklarkilisesi", "Karin", "Daroynk", "Owshank", "Baghesh", "Pasen", "Tercan"],
+        "culture": "armenian"
+    },
+    "Theodosiopolis": {
+        "settlements": ["Satala", "Thera", "Askale", "Argyropolis", "Oukhiti", "Tortum", "Theodosiopolis", "Citharizum"],
+        "culture": "armenian"
+    },
+    "Chaldea": {
+        "settlements": ["Tilgarimo", "Heracleopolis", "Cotyora", "Sebastea", "Ibora", "Podandos", "Camachus", "Kerasous"],
+        "culture": "greek"
+    },
+    "Koloneia": {
+        "settlements": ["Gerjanis", "Mazaka", "Gamakh", "Tephrice", "Akn", "Anatolnikopolis", "Celtzene", "Koloneia"],
+        "culture": "armenian"
+    },
+    "Melitene": {
+        "settlements": ["Samosata", "Kigi", "Arguvan", "Arca", "Seneqerim", "Melitene", "Corduene", "Yedisu"],
+        "culture": "armenian"
+    },
+    "Tell Bashir": {
+        "settlements": ["Turbessel", "Manbij", "Zeugma", "Birtha", "Jarabulus", "Makedonopolis", "Buzaa", "Nizip"],
+        "culture": "levantine_arabic"
+    },
+    "Asas": {
+        "settlements": ["Tabqa", "Zaazouaa", "Asas", "Kallinikos", "Resafa", "Rakka", "Talabyad", "Souriya"],
+        "culture": "levantine_arabic"
+    },
+    "Suffolk": {
+        "settlements": ["Dunwich", "Bury", "Bungay", "Framlingham", "Ely", "Stow", "Ipswich", "Lowestoft"],
+        "culture": "saxon"
+    },
+    "Al Bichri": {
+        "settlements": ["Sirhi", "Deiralzur", "Shamiyya", "Mayadin", "Mhaymidah", "Osrhoene", "Bichri", "Abu Kamal"],
+        "culture": "levantine_arabic"
+    },
+    "Sinjar": {
+        "settlements": ["Hatra", "Telassar", "Baaj", "Kouyunik", "Nineveh", "Talkayf", "Nabiyunus", "Sinjar"],
+        "culture": "assyrian"
+    },
+    "Rahbah": {
+        "settlements": ["Taraba", "Qummoualad", "Tlilin", "Anah", "Rahbah", "Nimreh", "Busan", "Salah"],
+        "culture": "assyrian"
+    },
+    "Druz": {
+        "settlements": ["Salkhard", "Awas", "Shannireh", "Samj", "Thoula", "Dibin", "Ghariyah", "Busra"],
+        "culture": "levantine_arabic"
+    },
+    "Az Zarqa": {
+        "settlements": ["Hashemiyya", "Khurqah", "Qasr Amra", "Russeifa", "Amratamad", "Zarqa", "Shabib", "Qasr Al Hallabat"],
+        "culture": "levantine_arabic"
+    },
+    "Al Habbariyah": {
+        "settlements": ["Shabakah", "Nuayj", "Qutaysh", "Alhabbariyah", "Daydab", "Nukhaib", "Aljirami", "Adhaman"],
+        "culture": "levantine_arabic"
+    },
+    "Zanjan Abhar": {
+        "settlements": ["Aba", "Wasamkuh", "Zahanj", "Abhar"],
+        "culture": "persian"
+    },
+    "Ar Ar": {
+        "settlements": ["Ammaryah", "Umm Kunsur", "Ruthiyah", "Judaidah", "Shaka", "Dumat Al Jundal", "Uwayquilah", "Qasa"],
+        "culture": "levantine_arabic"
+    },
+    "Jeddah": {
+        "settlements": ["Khulays", "Jeddah", "As Sirrayn"],
+        "culture": "bedouin_arabic"
+    },
+    "Al Jawf": {
+        "settlements": ["Sakakah", "Tuwayr", "Radifah", "Al Jawf", "Qurayyat", "Dumat Al Jandal", "Aladan", "Tyer"],
+        "culture": "levantine_arabic"
+    },
+    "Medina": {
+        "settlements": ["Farsh", "Medina", "Batn Nakhl", "Al Usayla", "Sidi Hamzah", "Milha", "Kuba"],
+        "culture": "bedouin_arabic"
+    },
+    "Mecca": {
+        "settlements": ["Jmumum", "Qunfudhah", "Al Lith", "Qarn", "Taif", "Mecca", "Al Johfa", "Turubah"],
+        "culture": "bedouin_arabic"
+    },
+    "Essex": {
+        "settlements": ["Havering", "Colchester", "Hedingham", "Dunmow", "Maldon", "Waltham", "Barking", "Pleshey"],
+        "culture": "saxon"
+    },
+    "Hijaz": {
+        "settlements": ["Al Ola", "Tayma", "Madain Salih", "Higra", "Tawala", "Samur", "Mughayra", "Leuke Kome"],
+        "culture": "levantine_arabic"
+    },
+    "Tabuk": {
+        "settlements": ["Tabuk", "Muwaylih", "Abu Ujayyijat", "Shaghab", "Gabouk", "Mariyiat", "Sharmah", "Duba"],
+        "culture": "levantine_arabic"
+    },
+    "Al Aqabah": {
+        "settlements": ["Quwairah", "Reeshah", "Elifaz", "Yotvata", "Aqabah", "Samar", "Feifa", "Mazraa"],
+        "culture": "levantine_arabic"
+    },
+    "Petra": {
+        "settlements": ["Tophel", "Shoubak", "Hamza", "Husseiniya", "Bozrah", "Petra", "Abdelliya", "Wadi Musa"],
+        "culture": "levantine_arabic"
+    },
+    "Madaba": {
+        "settlements": ["Wadi Al Sir", "Madaba", "Sahab", "Bilal", "Muwaqqar", "Samhal", "Qastal", "Umm Ar-Rasas"],
+        "culture": "levantine_arabic"
+    },
+    "Amman": {
+        "settlements": ["Fuheis", "Jerash", "Dhiban", "Deir Alla", "Amman", "Al Balqa", "Salt", "Mahis"],
+        "culture": "levantine_arabic"
+    },
+    "Irbid": {
+        "settlements": ["Ummqais", "Gadera", "Aydoun", "Aljun", "Habisjaldak", "Irbid", "Yarmouk", "Pella"],
+        "culture": "levantine_arabic"
+    },
+    "Al Mafraq": {
+        "settlements": ["Thughra", "Jarash", "Elemtaih", "Taebah", "Ramtah", "Mafraq", "Nasib", "Buwayda"],
+        "culture": "levantine_arabic"
+    },
+    "Syria": {
+        "settlements": ["Adra", "Buraq - Castle", "Jarba", "Hayjanah", "Otaybah", "Amrah", "Qasmiye", "Baly"],
+        "culture": "levantine_arabic"
+    },
+    "Damascus": {
+        "settlements": ["Qsarbardawil", "Izra", "Alsanamayn", "Suada", "Daraa", "Duma", "Shahba", "Damascus"],
+        "culture": "levantine_arabic"
+    },
+    "Tadmor": {
+        "settlements": ["Subaykhan", "Assusah", "Husaiba", "Bukamal", "Asharah", "Alqunjah", "Alqaim", "Salhiyah"],
+        "culture": "levantine_arabic"
+    },
+    "Kent": {
+        "settlements": ["Lympne", "Faversham", "Sandwich", "Tonbridge", "Canterbury", "Dover", "Rochester", "Romney"],
+        "culture": "saxon"
+    },
+    "Palmyra": {
+        "settlements": ["Arraml", "Palmyra", "Arak", "Khirbat", "Alqasr", "Jihar", "Alhuwaysis"],
+        "culture": "levantine_arabic"
+    },
+    "Homs": {
+        "settlements": ["Qatna", "Sadad", "Alkhazandar", "Qadesh", "Homs", "Zweitina", "Marmarita", "Emesa"],
+        "culture": "levantine_arabic"
+    },
+    "Hama": {
+        "settlements": ["Hama", "Qarqar", "Hamath", "Serjilla", "Kharsan", "Mhardeh", "Salamiyah"],
+        "culture": "levantine_arabic"
+    },
+    "Aleppo": {
+        "settlements": ["Aleppo", "Sarmin", "Harim", "Qusayr", "Azaz", "Maaratannuman", "Lerminet"],
+        "culture": "levantine_arabic"
+    },
+    "Aintab": {
+        "settlements": ["Amanus", "Aintab", "Hromgla", "Duluk", "Raban", "Marash", "Kyrrhos", "Ravendan"],
+        "culture": "armenian"
+    },
+    "Teluch": {
+        "settlements": ["Hajin", "Koksen", "Komanal", "Kapan", "Tavplur", "Perre", "Teluch", "Germanias"],
+        "culture": "greek"
+    },
+    "Lykandos": {
+        "settlements": ["Tzamandos", "Germanikeia", "Lykandos", "Cocussus", "Comanagene", "Papurius", "Arabissus", "Symposion"],
+        "culture": "greek"
+    },
+    "Kaisereia": {
+        "settlements": ["Masaka", "Misti", "Dobada", "Zoropassos", "Sariz", "Venessa", "Talas", "Kaisereia"],
+        "culture": "greek"
+    },
+    "Amisos": {
+        "settlements": ["Dazimon", "Neokaisarea", "Zela", "Thermodon", "Amasia", "Amisos", "Phadisane"],
+        "culture": "greek"
+    },
+    "Sinope": {
+        "settlements": ["Germanicopolis", "Pompeiopolis", "Aboniteichos", "Sinope", "Amastris", "Talaura", "Comana", "Themiscyra"],
+        "culture": "greek"
+    },
+    "Guines": {
+        "settlements": ["Calais", "Dunkerque", "Bourbourg", "Saintomer", "Gravelines", "Marck", "Guines", "Coulogne"],
+        "culture": "old_frankish"
+    },
+    "Herakleia": {
+        "settlements": ["Polis", "Flaviopolis", "Claudiopolis", "Amastrine", "Bithynium", "Tium", "Herakleia", "Zephyropoli"],
+        "culture": "greek"
+    },
+    "Nikomedeia": {
+        "settlements": ["Chalkedon", "Nikomedeia", "Praenetos", "Palodes", "Calpe", "Adapazari", "Malagina"],
+        "culture": "greek"
+    },
+    "Prusa": {
+        "settlements": ["Docimium", "Adrastea", "Darieium", "Thyatira", "Miletopolis", "Pelopia", "Prusa", "Apamea"],
+        "culture": "greek"
+    },
+    "Kyzikos": {
+        "settlements": ["Militopolis", "Artake", "Myrina", "Arisbe", "Percote", "Kremasti", "Kyzikos", "Adrianutherai"],
+        "culture": "greek"
+    },
+    "Abydos": {
+        "settlements": ["Allianoi", "Elaia", "Pigai", "Alexandriatroas", "Aegae", "Cebrene", "Abydos"],
+        "culture": "greek"
+    },
+    "Smyrna": {
+        "settlements": ["Phokaia", "Klazomeanai", "Smyrna", "Pergamon", "Chio", "Kydonia", "Erythrai", "Adramyttion"],
+        "culture": "greek"
+    },
+    "Ephesos": {
+        "settlements": ["Palation", "Iassos", "Ephesos", "Tralles", "Magnesia", "Petron", "Miletos"],
+        "culture": "greek"
+    },
+    "Lykia": {
+        "settlements": ["Limyra", "Mylasa", "Halikarnassos", "Phaselis", "Telmissos", "Kibyra", "Patara", "Myra"],
+        "culture": "greek"
+    },
+    "Laodikeia": {
+        "settlements": ["Gordes", "Laodikeia", "Philadelphia", "Hieropolis", "Kona", "Rhoas", "Sardes", "Flaviupolis"],
+        "culture": "greek"
+    },
+    "Dorylaion": {
+        "settlements": ["Polybotos", "Iustinianopolis", "Germia", "Kotiaion", "Orkistos", "Dorylaion", "Carura", "Pessinus"],
+        "culture": "greek"
+    },
+    "Boulogne": {
+        "settlements": ["Ardres", "Fauquembergues", "Boulogne", "Saintpol", "Therouanne", "Ternouis", "Montreuil", "Hesdin"],
+        "culture": "old_frankish"
+    },
+    "Nikaea": {
+        "settlements": ["Modrene", "Kotyaion", "Petobriga", "Optimatum", "Palaeokastron", "Yalova", "Nikaea", "Kios"],
+        "culture": "greek"
+    },
+    "Paphlagonia": {
+        "settlements": ["Safranbolu", "Leontopolis", "Kastamonu", "Zaliscus", "Anastasiopolis", "Cabira", "Gangra", "Bolu"],
+        "culture": "greek"
+    },
+    "Galatia": {
+        "settlements": ["Nyssa", "Kochisar", "Asponia", "Garsaura", "Karacaviran", "Mikissos", "Tavia", "Carissa"],
+        "culture": "greek"
+    },
+    "Ankyra": {
+        "settlements": ["Germa", "Amorion", "Ankyra", "Gordoservon", "Haymana", "Nakoleia", "Akroynon", "Gordium"],
+        "culture": "greek"
+    },
+    "Sozopolis": {
+        "settlements": ["Aezani", "Souzopolis", "Synnada", "Cadi", "Dinar", "Polidorion", "Isparta", "Kelainai"],
+        "culture": "greek"
+    },
+    "Attaleia": {
+        "settlements": ["Sagalassos", "Side", "Slege", "Cibyra", "Panemotichus", "Sillyon", "Galanauros", "Attaleia"],
+        "culture": "greek"
+    },
+    "Limisol": {
+        "settlements": ["Khirokitia", "Agridi", "Limmassol", "Dieudamour", "Morphou", "Kolossi", "Arsinoe", "Paphos"],
+        "culture": "greek"
+    },
+    "Famagusta": {
+        "settlements": ["Famagusta", "Buffavento", "Nikosia", "Cithium", "Kyrenia", "Kantara", "Peristerona", "Sthilarion"],
+        "culture": "greek"
+    },
+    "Seleukeia": {
+        "settlements": ["Ninica", "Germanak", "Selinus", "Irenopolis", "Anemurium", "Dalisandus", "Seleukeia", "Corycus"],
+        "culture": "greek"
+    },
+    "Ikonion": {
+        "settlements": ["Terpe", "Gaspadale", "Ikonion", "Lisdra", "Isauria", "Laranda", "Sauatra", "Amblada"],
+        "culture": "greek"
+    },
+    "Yperen": {
+        "settlements": ["Ypres", "Cassel", "Rosebeke", "Menen", "Roeselare", "Wervik", "Diksmuide", "Poperinge"],
+        "culture": "old_frankish"
+    },
+    "Tyana": {
+        "settlements": ["Tyana", "Nazianus", "Archelais", "Tomarza", "Anatoliaheraklea", "Gamar", "Faustinopolis", "Cybistra"],
+        "culture": "greek"
+    },
+    "Tarsos": {
+        "settlements": ["Pendosis", "Korikos", "Lamas", "Castabala", "Lampron", "Tarsos", "Zephyrium", "Bardzerben"],
+        "culture": "greek"
+    },
+    "Adana": {
+        "settlements": ["Trazak", "Lajazzo", "Mopsuestia", "Mamistra", "Sis", "Vahka", "Adana", "Anazarba"],
+        "culture": "greek"
+    },
+    "Alexandretta": {
+        "settlements": ["Myriandros", "Rhosus", "Portella", "Portbonnel", "Sarvantikar", "Alexandretta", "Derbasak", "Larochederissole"],
+        "culture": "greek"
+    },
+    "Antiocheia": {
+        "settlements": ["Saone", "Harenc", "Antiocheia", "Baghras", "Hazart", "Darbsak", "Stsymeon", "Latakiah"],
+        "culture": "greek"
+    },
+    "Archa": {
+        "settlements": ["Masyaf", "Kafroun", "Shayzar", "Chastelblanc", "Archa", "Treiz", "Famia"],
+        "culture": "levantine_arabic"
+    },
+    "Tortosa": {
+        "settlements": ["Maraclea", "Jabala", "Valania", "Balemia", "Ruad", "Margat", "Alkhawabi", "Tortosa"],
+        "culture": "levantine_arabic"
+    },
+    "Tripoli": {
+        "settlements": ["Alqulayat", "Alqadmus", "Nephin", "Boutron", "Syrtripoli", "Besmedin", "Arqah", "Gibelet"],
+        "culture": "levantine_arabic"
+    },
+    "Baalbek": {
+        "settlements": ["Akkar", "Buissera", "Krakdeschevaliers", "Baalbek", "Chlifa", "Laboue", "Riyaq", "Zahle", "Halbah"],
+        "culture": "levantine_arabic"
+    },
+    "Safed": {
+        "settlements": ["Subeiba", "Banyas", "Safed", "Karmel", "Chastelet", "Belvoir", "Qatsrin", "Toron"],
+        "culture": "levantine_arabic"
+    },
+    "Artois": {
+        "settlements": ["Beaumetz", "Bouvines", "Bethune", "Arras", "Bapaume", "Lille", "Lens", "Terwaan"],
+        "culture": "old_frankish"
+    },
+    "Beirut": {
+        "settlements": ["Beirut", "Sarepta", "Cavedetyron", "Sidon", "Journie", "Abualhasan", "Beitkfeya"],
+        "culture": "levantine_arabic"
+    },
+    "Tyrus": {
+        "settlements": ["Casalimbert", "Megedel", "Scandalon", "Syrbelfort", "Sarafand", "Hunin", "Syrmontfort", "Tyrus"],
+        "culture": "levantine_arabic"
+    },
+    "Acre": {
+        "settlements": ["Adelon", "Recordana", "Athlith", "Haifa", "Acre", "Syrcaesarea", "Merle", "Manawat"],
+        "culture": "levantine_arabic"
+    },
+    "Tiberias": {
+        "settlements": ["Lafeve", "Bethsan", "Hattin", "Ashtera", "Tiberias", "Nazareth", "Caymont"],
+        "culture": "levantine_arabic"
+    },
+    "Jerusalem": {
+        "settlements": ["Beitnuba", "Nablus", "Mirabel", "Saintsamuel", "Jerusalem", "Rammala", "Jericho"],
+        "culture": "levantine_arabic"
+    },
+    "Jaffa": {
+        "settlements": ["Ramleh", "Lydda", "Yazur", "Beitdejan", "Qula", "Jaffa", "Arsuf", "Ibelin"],
+        "culture": "levantine_arabic"
+    },
+    "Hebron": {
+        "settlements": ["Bethlehem", "Hebron", "Deimachar", "Bethgibelin", "Latrun", "Alsamoa", "Syrbelmont", "Saintcharlton"],
+        "culture": "levantine_arabic"
+    },
+    "Kerak": {
+        "settlements": ["Punon", "Kirhaseset", "Zoar", "Krakdemoab", "Bozra", "Zaimona", "Tamar", "Kerak"],
+        "culture": "levantine_arabic"
+    },
+    "Monreal": {
+        "settlements": ["Monreal", "Hurmniz", "Paran", "Idan", "Sela", "Tafila", "Bildad"],
+        "culture": "levantine_arabic"
+    },
+    "Beersheb": {
+        "settlements": ["Rahat", "Estemon", "Gilat", "Ofakim", "Debir", "Beersheb", "Massada", "Abuzqayqa"],
+        "culture": "levantine_arabic"
+    },
+    "Brugge": {
+        "settlements": ["Male", "Oostende", "Nieuwpoort", "Torhout", "Brugge", "Damme", "Aardenburg", "Sluys"],
+        "culture": "old_frankish"
+    },
+    "Ascalon": {
+        "settlements": ["Ascalon", "Semsem", "Agelen", "Huidre", "Blanchegarde", "Laforbie", "Harbijah", "Bothme"],
+        "culture": "levantine_arabic"
+    },
+    "Darum": {
+        "settlements": ["Gaza", "Abasan", "Darum", "Radwan", "Gerar", "Salqah", "Rafah", "Jarara"],
+        "culture": "levantine_arabic"
+    },
+    "Negev": {
+        "settlements": ["Avdat", "Haluza", "Negev", "Dimona", "Albaqar", "Ezuz", "Kmehin", "Yeruham"],
+        "culture": "levantine_arabic"
+    },
+    "Maan": {
+        "settlements": ["Buseira", "Maanalhasa", "Mutah", "Afra", "Shubak", "Bubeita", "Maan", "Maanaljafr"],
+        "culture": "levantine_arabic"
+    },
+    "Shahrazur": {
+        "settlements": ["Shahrazur", "Sanda"],
+        "culture": "kurdish"
+    },
+    "Sinai": {
+        "settlements": ["Sinbarqa", "Jabalsamra", "Mamlah", "Nabq", "Sharmelsheikh", "Dahab", "Attur", "Nuweiba"],
+        "culture": "levantine_arabic"
+    },
+    "Eilat": {
+        "settlements": ["Eliot", "Yahel", "Tzofar", "Ketura", "Sapir", "Lotan", "Eilat", "Urim"],
+        "culture": "levantine_arabic"
+    },
+    "El-Arish": {
+        "settlements": ["Kharruba", "Abuaweigila", "Birelhamma", "Zuwayid", "Arish", "Masyada", "Tukkot", "Mitmatna"],
+        "culture": "levantine_arabic"
+    },
+    "Farama": {
+        "settlements": ["Mustabiq", "Seyan", "Romani", "Sin", "Farama", "Zaaraniq", "Birqatia", "Birelabd"],
+        "culture": "levantine_arabic"
+    },
+    "Pelusia": {
+        "settlements": ["Pithom", "Said", "Alsalihiyah", "Tinis", "Ismaillia", "Serapeum", "Pelusia", "Sile"],
+        "culture": "egyptian_arabic"
+    },
+    "Zeeland": {
+        "settlements": ["Zierikzee", "Cadzand", "Middelburg", "Borsele", "Veere", "Renesse", "Vlissingen"],
+        "culture": "frisian"
+    },
+    "Sarqihya": {
+        "settlements": ["Clysma", "Suez", "Shallufa", "Alhaifar", "Atfih", "Agruda", "Sarqinya", "Taufiq"],
+        "culture": "egyptian_arabic"
+    },
+    "Quena": {
+        "settlements": ["Qift", "Qus", "Abughusun", "Ummrus", "Quena", "Safaga", "Kosseir"],
+        "culture": "egyptian_arabic"
+    },
+    "Nubia": {
+        "settlements": ["Anag", "Salala", "Tahtani", "Nafab", "Komotit", "Fanoidig", "Eirayab"],
+        "culture": "nubian"
+    },
+    "Makuria": {
+        "settlements": ["Dongola", "Kawa", "Gabriya", "Qubban", "Kerma", "Kerat", "Affat"],
+        "culture": "nubian"
+    },
+    "Aswan": {
+        "settlements": ["Aswan", "Philae", "Edfu", "Shellal", "Elefantina", "Veset", "Kalabsha", "Bigeh"],
+        "culture": "egyptian_arabic"
+    },
+    "Asyut": {
+        "settlements": ["Asyut", "Egypabydos", "Meir", "Luxor", "Beitkhallaf", "Durunka", "Egypthebes", "Kusai", "Wannina"],
+        "culture": "egyptian_arabic"
+    },
+    "Cairo": {
+        "settlements": ["Maadi", "Fustat", "Cairo", "Tekkekyahudiyya", "Memphis", "Helwan", "Heliopolis", "Merimdabenisalama"],
+        "culture": "egyptian_arabic"
+    },
+    "Manupura": {
+        "settlements": ["Bubastis", "Qantir", "Manusura", "Bilbays", "Zagazig", "Almahallah", "Busiris", "Athribis"],
+        "culture": "egyptian_arabic"
+    },
+    "Delta": {
+        "settlements": ["Burah", "Baramun", "Tanis", "Saramsah", "Burlus", "Fareskur", "Shirbin", "Damietta"],
+        "culture": "egyptian_arabic"
+    },
+    "Gabiyaha": {
+        "settlements": ["Buto", "Disuq", "Mutubis", "Xois", "Sais", "Hermopolis", "Rosetta", "Fuwa"],
+        "culture": "egyptian_arabic"
+    },
+    "Breifne": {
+        "settlements": ["Cavan", "Kilmore", "Longford", "Ardagh", "Dromahair", "Leitrim", "Drumcliffe", "Kells"],
+        "culture": "irish"
+    },
+    "Holland": {
+        "settlements": ["Vlaardingen", "Haarlem", "Leiden", "Gouda", "Dordrecht", "Muiden", "Amsterdam", "Sgravenhage"],
+        "culture": "frisian"
+    },
+    "Gizeh": {
+        "settlements": ["Zawyetalayran", "Abusir", "Ellisht", "Dashur", "Gizeh", "Aburowash", "Abughorob", "Saqqara"],
+        "culture": "egyptian_arabic"
+    },
+    "Buhairya": {
+        "settlements": ["Elkharga", "Qasrfarfra", "Baris", "Budhkula", "Mut", "Abuminqar", "Buhairya", "Ismant"],
+        "culture": "nubian"
+    },
+    "Alexandria": {
+        "settlements": ["Burgelarab", "Hammam", "Marabout", "Abukir", "Alexandria", "Elkanoun", "Naucratis", "Damanhur"],
+        "culture": "egyptian_arabic"
+    },
+    "Quattara": {
+        "settlements": ["Alamelshwawish", "Siwa", "Qaretagnes", "Caraoasis", "Dayr", "Ziwaelbahari", "Abdannabi", "Quattara"],
+        "culture": "egyptian_arabic"
+    },
+    "Al Alamayn": {
+        "settlements": ["Paraitonion", "Ghazal", "Shammas", "Elalamein", "Sidibarrani", "Fuka", "Katabathmos", "Mersamatruh"],
+        "culture": "egyptian_arabic"
+    },
+    "Tobruk": {
+        "settlements": ["Tobruk", "Bardia", "Kambut", "Alqardabah", "Rukbah", "Acroma", "Zanzur", "Sollum"],
+        "culture": "maghreb_arabic"
+    },
+    "Cyrenaica": {
+        "settlements": ["Alqubbah", "Altamimi", "Khadra", "Athrun", "Marsasusah", "Mukhayta", "Derna", "Cyrene"],
+        "culture": "maghreb_arabic"
+    },
+    "Senoussi": {
+        "settlements": ["Kufra", "Gabr", "Tazirbu", "Jakharrah", "Buzayman", "Attallab", "Jalu", "Attaj"],
+        "culture": "maghreb_arabic"
+    },
+    "Benghazi": {
+        "settlements": ["Benghazi", "Ajdabiya", "Barca", "Daryanah", "Jardinah", "Oriana", "Tansulukh", "Tulmaytath"],
+        "culture": "maghreb_arabic"
+    },
+    "Syrte": {
+        "settlements": ["Syrte", "Lanuf", "Assultan", "Bishr", "Nawfalliyah", "Qaryatbishr", "Assidr", "Abuhadi"],
+        "culture": "maghreb_arabic"
+    },
+    "Westfriesland": {
+        "settlements": ["Heerhugowaard", "Medemblik", "Texel", "Alkmaar", "Enkhuizen", "Schagen", "Egmond", "Hoorn"],
+        "culture": "frisian"
+    },
+    "Leptis Magna": {
+        "settlements": ["Alghiran", "Leptismagna", "Naimah", "Misratah", "Alhasun", "Qirdah", "Gioda", "Abunujaym"],
+        "culture": "maghreb_arabic"
+    },
+    "Tripolitana": {
+        "settlements": ["Mazuzah", "Aljamil", "Sabratah", "Libtripoli", "Baniwaled", "Nalut", "Funduq", "Gherlan"],
+        "culture": "maghreb_arabic"
+    },
+    "Malta": {
+        "settlements": ["Mdina", "Sliema", "Gozo", "Sanpawl", "Marsascala", "Sangjilan", "Birzebbuga", "Mgarr"],
+        "culture": "greek"
+    },
+    "Djerba": {
+        "settlements": ["Taguermess", "Cedriane", "Houmtsouk", "Aghir", "Ajim", "Elmey", "Abarda", "Midoun"],
+        "culture": "maghreb_arabic"
+    },
+    "Gabes": {
+        "settlements": ["Tataouine", "Gabes", "Alqalah", "Steftimi", "Aljanain", "Medenine", "Haddej", "Kebili"],
+        "culture": "maghreb_arabic"
+    },
+    "Kairwan": {
+        "settlements": ["Kairouan", "Meknassy", "Tozeur", "Sidibouzid", "Haffouz", "Sidimansour", "Gafsa", "Chebika"],
+        "culture": "maghreb_arabic"
+    },
+    "Mahdia": {
+        "settlements": ["Sfax", "Neffatia", "Lacroix", "Agareb", "Msaken", "Mahdia", "Monastir"],
+        "culture": "maghreb_arabic"
+    },
+    "Tunis": {
+        "settlements": ["Ariana", "Zaghouan", "Kelibia", "Hammamet", "Benarous", "Tunis", "Sousse", "Cartaghe"],
+        "culture": "maghreb_arabic"
+    },
+    "Medjerda": {
+        "settlements": ["Elkrib", "Medjerda", "Qaafur", "Sidimubarak", "Dougga", "Lekef", "Kasserine", "Siliana"],
+        "culture": "maghreb_arabic"
+    },
+    "Bizerte": {
+        "settlements": ["Netza", "Ghezala", "Almatin", "Jendouba", "Tunbeja", "Bizerte", "Tamra", "Manziljamal"],
+        "culture": "maghreb_arabic"
+    },
+    "Sticht": {
+        "settlements": ["Buren", "Dorestad", "Woerden", "Ijsselstein", "Utrecht", "Oudewater", "Gorinchem", "Zeist"],
+        "culture": "frisian"
+    },
+    "Annaba": {
+        "settlements": ["Eltarf", "Soukahras", "Drean", "Skikda", "Meroudj", "Elbouni", "Boudjama", "Annabah"],
+        "culture": "maghreb_arabic"
+    },
+    "Constantine": {
+        "settlements": ["Tadjenanet", "Guelma", "Mechtakebira", "Elkhroub", "Tebessa", "Constantine", "Oumelbouaghi", "Guerrah"],
+        "culture": "maghreb_arabic"
+    },
+    "Bejaija": {
+        "settlements": ["Elbekara", "Gantas", "Eldjabia", "Mila", "Jijel", "Boudaoud", "Setif", "Bejaija"],
+        "culture": "maghreb_arabic"
+    },
+    "Biskra": {
+        "settlements": ["Mekhadma", "Batna", "Bigou", "Branis", "Nebka", "Biskra", "Sidiokba", "Khenchela"],
+        "culture": "maghreb_arabic"
+    },
+    "Tell Atlas": {
+        "settlements": ["Mirabeau", "Zaoula", "Akaoudj", "Tagoughalt", "Tiziouzou", "Nacina", "Draaelmizan", "Mechreck"],
+        "culture": "maghreb_arabic"
+    },
+    "Beni Yanni": {
+        "settlements": ["Bujima", "Tafoughalt", "Taoudouch", "Thiza", "Azeffoun", "Tigzirt", "Azazga", "Bourmedes"],
+        "culture": "maghreb_arabic"
+    },
+    "Menorca": {
+        "settlements": ["Escastell", "Alaior", "Santlluis", "Santaagueda", "Esmercadal", "Ferreries", "Mahon"],
+        "culture": "visigothic"
+    },
+    "Mallorca": {
+        "settlements": ["Santaponsa", "Eivissa", "Palma", "Formentera", "Manacor", "Felanitx", "Alcudia", "Algaida"],
+        "culture": "visigothic"
+    },
+    "Ouled Nail": {
+        "settlements": ["Msila", "Beneldir", "Ainzia", "Sidinhar", "Bordjelcaid", "Sidiheg", "Tubirett", "Roumana"],
+        "culture": "maghreb_arabic"
+    },
+    "Mzab": {
+        "settlements": ["Elbour", "Ouargla", "Zelfana", "Noumerat", "Mzab", "Elalia", "Bermane", "Sebseb"],
+        "culture": "maghreb_arabic"
+    },
+    "Gelre": {
+        "settlements": ["Zwolle", "Deventer", "Zutphen", "Bronckhorst", "Bergh", "Arnhem", "Nijmegen", "Kampen"],
+        "culture": "frisian"
+    },
+    "Lemdiyya": {
+        "settlements": ["Aintorki", "Aindefla", "Blida", "Sidimohammed", "Relizane", "Medea", "Elhachem", "Elrhenb"],
+        "culture": "maghreb_arabic"
+    },
+    "Al Djazair": {
+        "settlements": ["Tipasa", "Algiers", "Rhedadoua", "Elachour", "Chiffa", "Elrdair", "Sidiakacha", "Tirourda"],
+        "culture": "maghreb_arabic"
+    },
+    "Orania": {
+        "settlements": ["Oran", "Mostaganem", "Gdyel", "Merselhadjad", "Ainelberd", "Aintemouchent", "Benisaf", "Maghnia"],
+        "culture": "maghreb_arabic"
+    },
+    "Atlas Mnt": {
+        "settlements": ["Ainzmila", "Bordj", "Ainrich", "Tiaret", "Elyourh", "Hassibenmadjeb", "Djelfa", "Selmana"],
+        "culture": "maghreb_arabic"
+    },
+    "Tlemcen": {
+        "settlements": ["Tlemcen", "Bedrabine", "Tessala", "Letelagh", "Elhaicaiba", "Dhaya", "Muaskar", "Sidibelabbes"],
+        "culture": "maghreb_arabic"
+    },
+    "Hanyan": {
+        "settlements": ["Alancha", "Hanyan", "Magoura", "Raselma", "Saida", "Alkasdir", "Naama", "Bougtob"],
+        "culture": "maghreb_arabic"
+    },
+    "Snassen": {
+        "settlements": ["Ahfir", "Berkane", "Jerada", "Oujda", "Debdou", "Tendrara", "Ainbenimathar", "Saldia"],
+        "culture": "maghreb_arabic"
+    },
+    "Figuig": {
+        "settlements": ["Benitajjit", "Boudnib", "Figuig", "Ainechchair", "Bouarfa", "Bechar", "Ich", "Safsaf"],
+        "culture": "maghreb_arabic"
+    },
+    "El Rif": {
+        "settlements": ["Midar", "Melilla", "Ketama", "Geurcif", "Saka", "Nador", "Driouch", "Alhoceima"],
+        "culture": "maghreb_arabic"
+    },
+    "Cebta": {
+        "settlements": ["Targuist", "Martil", "Babtaza", "Mdiq", "Aulef", "Tetouan", "Cueta", "Xauen"],
+        "culture": "maghreb_arabic"
+    },
+    "Frisia": {
+        "settlements": ["Harlingen", "Bolsward", "Leeuwarden", "Stavoren", "Dokkum", "Assen", "Franeker", "Groningen"],
+        "culture": "frisian"
+    },
+    "Fes": {
+        "settlements": ["Elhajeb", "Zerhoun", "Sefrou", "Bouanane", "Fes", "Missour", "Meknes", "Enjil"],
+        "culture": "maghreb_arabic"
+    },
+    "Tangiers": {
+        "settlements": ["Charkia", "Tangiers", "Mulaybuselham", "Alcazarquivir", "Barrha", "Laraiche", "Ainbenamar", "Asilah"],
+        "culture": "maghreb_arabic"
+    },
+    "Infa": {
+        "settlements": ["Azemmour", "Tiflet", "Infa", "Berrechid", "Oulmes", "Sale", "Khouribga", "Rabat"],
+        "culture": "maghreb_arabic"
+    },
+    "Marrakech": {
+        "settlements": ["Demnat", "Alnif", "Ouarzazate", "Marrakech", "Elanakir", "Thineghir", "Asni", "Sidirahhal"],
+        "culture": "maghreb_arabic"
+    },
+    "Massat": {
+        "settlements": ["Agouidir", "Aguedal", "Haddraa", "Safi", "Qumelaioun", "Aitelaouni", "Akermoud", "Essaouira"],
+        "culture": "maghreb_arabic"
+    },
+    "Anti-Atlas": {
+        "settlements": ["Biourga", "Tata", "Argana", "Agadir", "Kasbaeljoua", "Illrh", "Taroudaut", "Alogoum"],
+        "culture": "maghreb_arabic"
+    },
+    "Ifni": {
+        "settlements": ["Tiznit", "Mihrleft", "Belkassem", "Guelmim", "Tizgui", "Ifni", "Rgab", "Ouaouteit"],
+        "culture": "maghreb_arabic"
+    },
+    "Tharasset": {
+        "settlements": ["Amot", "Tiglit", "Tantan", "Tharasset", "Tartaya", "Akhfennir", "Tidergit", "Chbika"],
+        "culture": "maghreb_arabic"
+    },
+    "Bremen": {
+        "settlements": ["Verden", "Achim", "Blumenthal", "Ritzebuttel", "Beverstedt", "Stade", "Bremen", "Hoya"],
+        "culture": "old_saxon"
+    },
+    "Canarias": {
+        "settlements": ["Alegranza", "Lapalma", "Fuerteventura", "Lanzarote", "Grancanaria", "Lagomera", "Tenerife", "Lagraciosa"],
+        "culture": "maghreb_arabic"
+    },
+    "Ostfriesland": {
+        "settlements": ["Wittmund", "Leer", "Borkum", "Norden", "Aurich", "Emden", "Norderney", "Esens"],
+        "culture": "frisian"
+    },
+    "Kandalax": {
+        "settlements": ["Sarapo", "Pyaozero", "Ponoy", "Kantalahti", "Kolsky", "Umba", "Lekastrom", "Varzuga"],
+        "culture": "not_lappish"
+    },
+    "Capua": {
+        "settlements": ["Gaeta", "Calvi", "Capua", "Montecassino", "Acerra", "Teano", "Caserta"],
+        "culture": "lombard"
+    },
+    "Zahedan": {
+        "settlements": ["Kacharud", "Khajeh", "Buk", "Golchah", "Hamun", "Jahangir", "Zahedan", "Kuhtaftan"],
+        "culture": "baloch"
+    },
+    "Bam": {
+        "settlements": ["Abeshkan", "Kaj", "Nukjub", "Bal Chah", "Bampur", "Baravat", "Fahraj", "Sol Hasan"],
+        "culture": "persian"
+    },
+    "Jask": {
+        "settlements": ["Hara Gabrik", "Band Jask", "Miski", "Zaharai", "Par Kun", "Rabag", "Yeldar", "Jagin"],
+        "culture": "baloch"
+    },
+    "Zamindawar": {
+        "settlements": ["Zamindawar", "Bishlang", "Khalai"],
+        "culture": "afghan"
+    },
+    "Mahra": {
+        "settlements": ["Haswayn", "Qishn", "Damqwat", "Alhalya", "Alkurah", "Nishtun", "Ghaydah", "Itab"],
+        "culture": "bedouin_arabic"
+    },
+    "Kathiri": {
+        "settlements": ["Lodar", "Mukalla", "Shabwa", "Seiyun", "Qana", "Nisab", "Azzan", "Shihar"],
+        "culture": "bedouin_arabic"
+    },
+    "Bayda": {
+        "settlements": ["Habban", "Alkhabr", "Timna", "Bayda", "Zinjibar", "Ataq", "Ashshubaykah", "Yashbum"],
+        "culture": "bedouin_arabic"
+    },
+    "Aden": {
+        "settlements": ["Alarbadi", "Dhala", "Alawbhali", "Almilah", "Jaar", "Alkawd", "Aden", "Lahej"],
+        "culture": "bedouin_arabic"
+    },
+    "Taizz": {
+        "settlements": ["Perim", "Jibla", "Ibb", "Shuqra", "Mocha", "Zafar", "Taizz", "Dhisufal"],
+        "culture": "bedouin_arabic"
+    },
+    "Oldenburg": {
+        "settlements": ["Varel", "Nordenham", "Jever", "Loningen", "Delmenhorst", "Kniphausen", "Cloppenburg", "Oldenburg"],
+        "culture": "old_saxon"
+    },
+    "Sanaa": {
+        "settlements": ["Jabaltiyal", "Dhamar", "Qataba", "Jabalannabishuayb", "Hodeida", "Marib", "Harib", "Sanaa"],
+        "culture": "bedouin_arabic"
+    },
+    "Asir": {
+        "settlements": ["Kuthba", "Kamaran", "Hajjah", "Sadah", "Tabala", "Dam", "Bahah"],
+        "culture": "bedouin_arabic"
+    },
+    "Halaban": {
+        "settlements": ["Arradum", "Aljammaniyah", "Alqaiyah", "Albijadiyah", "Albaharah", "Badaiidyan", "Almaklah"],
+        "culture": "bedouin_arabic"
+    },
+    "Hajr": {
+        "settlements": ["Baljurashi", "Bisha", "Jizan", "Khamismushait", "Almaqah", "Abha", "Alhudaydah"],
+        "culture": "bedouin_arabic"
+    },
+    "Hail": {
+        "settlements": ["Asshinan", "Iqdah", "Mawqaq", "Murayfiq", "Baqa", "Alghazalah", "Saban"],
+        "culture": "levantine_arabic"
+    },
+    "Rafha": {
+        "settlements": ["Uwayqilah", "Markuz", "Ashshir", "Timiat", "Lawqah", "Aljumaymah", "Duwayd"],
+        "culture": "levantine_arabic"
+    },
+    "Dhofar": {
+        "settlements": ["Raysut", "Durrah", "Shisr", "Salalah", "Harzan", "Amal", "Dawkah", "Thamarit"],
+        "culture": "bedouin_arabic"
+    },
+    "Duqm": {
+        "settlements": ["Aljazir", "Masirah", "Hubara", "Nimr", "Duqm", "Harima", "Mahut", "Bank", "Nizwa"],
+        "culture": "bedouin_arabic"
+    },
+    "Muscat": {
+        "settlements": ["Lizq", "Shiya", "Ibra", "Samail", "Adam", "Muscat", "Sur", "Sabt"],
+        "culture": "bedouin_arabic"
+    },
+    "Hajar": {
+        "settlements": ["Alhamra", "Ibri", "Jabrin", "Suhar", "Masruq", "Haran", "Yanqui"],
+        "culture": "bedouin_arabic"
+    },
+    "Osnabruck": {
+        "settlements": ["Bentheim", "Tecklenburg", "Meppen", "Lingen", "Quackenbruck", "Wildeshausen", "Minden", "Osnabruck"],
+        "culture": "old_saxon"
+    },
+    "Dhu Zabi": {
+        "settlements": ["Julfar", "Qutuf", "Dubai", "Sharjah", "Sohar", "Dibba", "Khorfakkan", "Dhuzabi"],
+        "culture": "bedouin_arabic"
+    },
+    "Busaso": {
+        "settlements": ["Garoowe", "Lasanod", "Qardho", "Erigavo", "Bandaraassim", "Buraan", "Hadaftimo", "Mosylon"],
+        "culture": "somali"
+    },
+    "Berbera": {
+        "settlements": ["Burco", "Shiikh", "Mandera", "Gabiley", "Maydh", "Daarbuduq", "Berbera"],
+        "culture": "somali"
+    },
+    "Harer": {
+        "settlements": ["Harar", "Alemaya", "Kurfachele", "Dakkar", "Kombolcha", "Babile", "Diridawa"],
+        "culture": "ethiopian"
+    },
+    "Tadjoura": {
+        "settlements": ["Tadjoura", "Randa", "Obock", "Holhol", "Djibouti", "Dikhil", "Berenice"],
+        "culture": "somali"
+    },
+    "Aksum": {
+        "settlements": ["Mekele", "Adigrat", "Adwa", "Hawzen", "Rama", "Yeha"],
+        "culture": "ethiopian"
+    },
+    "Akordat": {
+        "settlements": ["Akordat", "Mogolo", "Shambuko", "Barentu", "Dghe", "Teseney", "Antalla"],
+        "culture": "ethiopian"
+    },
+    "Kassala": {
+        "settlements": ["Doka", "Gherset", "Kagnarti", "Aroma", "Tebteb", "Dinder"],
+        "culture": "nubian"
+    },
+    "Hayya": {
+        "settlements": ["Taris", "Kataigarsa", "Gebeit", "Musmer", "Aliab", "Sinkat"],
+        "culture": "nubian"
+    },
+    "Atbara": {
+        "settlements": ["Atbara", "Begarawiyah", "Hajaralasla", "Ummmardi", "Abudis", "Meruwah", "Shendi"],
+        "culture": "nubian"
+    },
+    "Munster": {
+        "settlements": ["Steinfurt", "Dortmund", "Essen", "Gronau", "Ahlen", "Munster", "Gutersloh", "Greven"],
+        "culture": "old_saxon"
+    },
+    "Sennar": {
+        "settlements": ["Sennar", "Galgani", "Sinjah", "Bakkah", "Abbeit", "Kukur", "Wadrawah"],
+        "culture": "nubian"
+    },
+    "Asosa": {
+        "settlements": ["Kormuk", "Debrezeyit", "Genetemariam", "Ketema", "Asosa", "Mankush", "Bambasi", "Dibate"],
+        "culture": "ethiopian"
+    },
+    "Ankober": {
+        "settlements": ["Berehet", "Tegulet", "Keyagebriel", "Saqqa", "Doqaqit", "Qundi", "Aliyuamba"],
+        "culture": "ethiopian"
+    },
+    "Gondar": {
+        "settlements": ["Fasilghebbi", "Bahirdar", "Magdala", "Roha", "Dembiya", "Tanaqirqos", "Ambassel", "Gondar"],
+        "culture": "ethiopian"
+    },
+    "Antalo": {
+        "settlements": ["Bale", "Oromos", "Debrelibanos", "Debreberhan", "Antsokia", "Shewa", "Entoto", "Hayq"],
+        "culture": "ethiopian"
+    },
+    "Matamma": {
+        "settlements": ["Yadeta", "Chiri", "Ginbo", "Gishabay", "Bonga", "Garo", "Kaffa", "Wacha"],
+        "culture": "ethiopian"
+    },
+    "Perm": {
+        "settlements": ["Chemuska", "Yagoshikha", "Biser", "Cherdyn", "Gorodki", "Lysva"],
+        "culture": "komi"
+    },
+    "Yamalia": {
+        "settlements": ["Obdorsk", "Urengoi", "Kaek", "Lapytnangk", "Nazym", "Baygul", "Ituyakha"],
+        "culture": "khanty"
+    },
+    "Komi": {
+        "settlements": ["Ustkolom", "Vorkuta", "Vorgashor", "Khalmeryu", "Kharp", "Aykino", "Usttsilma"],
+        "culture": "komi"
+    },
+    "Ural": {
+        "settlements": ["Satka", "Kaslinsky", "Ustkatav", "Kyshtym", "Asha", "Miass", "Chebarkul"],
+        "culture": "komi"
+    },
+    "Kleve": {
+        "settlements": ["Rees", "Kleve", "Emmerich", "Wesel", "Xanten", "Isselburg", "Goch", "Anholt"],
+        "culture": "german"
+    },
+    "Khantia": {
+        "settlements": ["Pnobe", "Beloyarskiy", "Berezovo", "Djinesh", "Nyagyn", "Sherkala", "Igrim"],
+        "culture": "khanty"
+    },
+    "Tyumen": {
+        "settlements": ["Tugulym", "Qashliq", "Novtap", "Sumkino", "Nizhtavda", "Borovskiy", "Tobolsk"],
+        "culture": "cuman"
+    },
+    "Mansia": {
+        "settlements": ["Pytyakh", "Poykovskiy", "Nefteyugansk", "Yalbak", "Yabin", "Mamontovo"],
+        "culture": "khanty"
+    },
+    "Sibir": {
+        "settlements": ["Baduk", "Belyyyar", "Kaik", "Vysokiy", "Surgut", "Langepas", "Iberbolgar", "Pokachi"],
+        "culture": "khanty"
+    },
+    "Saravan": {
+        "settlements": ["Pahrah", "Sarbaz", "Jaleq", "Khash", "Sangan", "Pishin", "Saravan", "Rasak"],
+        "culture": "baloch"
+    },
+    "Yaik": {
+        "settlements": ["Vagay", "Shumikha", "Mishkino", "Kyzalyar", "Makushino", "Lebyazhe", "Yurgamysh"],
+        "culture": "cuman"
+    },
+    "Aqtobe": {
+        "settlements": ["Shilikta", "Kunsay", "Zharlysay", "Ashchesay", "Sibiryak", "Aulkutyrtas"],
+        "culture": "cuman"
+    },
+    "Inder": {
+        "settlements": ["Dzhanatalap", "Kaumetey", "Karatogay", "Bogunbay", "Kemer", "Chausay", "Ebita"],
+        "culture": "cuman"
+    },
+    "Tobol": {
+        "settlements": ["Tyukalinsk", "Tara", "Kalachinsk", "Krasnyyar", "Isilkul", "Sargatka", "Cherlak"],
+        "culture": "cuman"
+    },
+    "Tis": {
+        "settlements": ["Regedan", "Pozm Machchan", "Sergen", "Kursar", "Parak", "Tis", "Chabahar", "Konarak"],
+        "culture": "baloch"
+    },
+    "Connacht": {
+        "settlements": ["Roscommon", "Anchory", "Killala", "Tuam", "Elphin", "Galway", "Clonfert", "Mayo"],
+        "culture": "irish"
+    },
+    "Julich": {
+        "settlements": ["Prum", "Geldern", "Moers", "Monschau", "Aachen", "Roermond", "Duren", "Julich"],
+        "culture": "old_frankish"
+    },
+    "Syr Darya": {
+        "settlements": ["Kazaly", "Kyzylorda", "Dzhanadzhol", "Zhalagash", "Akmechet", "Terenuzyak", "Sarytogay"],
+        "culture": "turkish"
+    },
+    "Kyzylkum": {
+        "settlements": ["Shovot", "Bogot", "Xazorasp", "Itchankila", "Qorovul", "Yangiariq", "Xonqa"],
+        "culture": "turkish"
+    },
+    "Dashhowuz": {
+        "settlements": ["Akdepe", "Boldumsaz", "Gorogly", "Tagta", "Gubadag", "Kunyaurgench", "Dashhowuz", "Yylanly"],
+        "culture": "persian"
+    },
+    "Samarkand": {
+        "settlements": ["Urgut", "Ziadin", "Afrasiyab", "Khokand", "Laish", "Ishtikhon", "Samarkand", "Koshrabot"],
+        "culture": "sogdian"
+    },
+    "Balkh": {
+        "settlements": ["Alkhanoum", "Dalverzintepe", "Balkh", "Tiliatepe", "Surkhkotal"],
+        "culture": "persian"
+    },
+    "Herat": {
+        "settlements": ["Chishti", "Farsi", "Herat", "Kushk", "Zarghun", "Karukh", "Gulran", "Obe"],
+        "culture": "persian"
+    },
+    "Birjand": {
+        "settlements": ["Furg", "Birjand", "Sarayan", "Qaen", "Boshruyeh", "Paeenshahr", "Toon", "Nehbandan"],
+        "culture": "persian"
+    },
+    "Mandesh": {
+        "settlements": ["Gozareh", "Saghar", "Baluci", "Kwajaha", "Chaghcharan", "Taywara", "Adraskan"],
+        "culture": "persian"
+    },
+    "Loon": {
+        "settlements": ["Tongeren", "Loon", "Hasselt", "Heinsberg", "Hesbaie", "Wassenberg", "Maastricht", "Valkenburg"],
+        "culture": "old_frankish"
+    },
+    "Timbuktu": {
+        "settlements": ["Salam", "Toya", "Aglal", "Timbuktu", "Ber", "Lafia"],
+        "culture": "manden"
+    },
+    "Aoudaghost": {
+        "settlements": ["Tichitt", "Moudjeria"],
+        "culture": "manden"
+    },
+    "Ghana": {
+        "settlements": ["Koumbi Saleh", "Singhanah", "El Ghaba", "Silla"],
+        "culture": "manden"
+    },
+    "Gao": {
+        "settlements": ["Gao", "Anchawadi", "Gabero", "Bourem", "Ansongo"],
+        "culture": "manden"
+    },
+    "Djenne": {
+        "settlements": ["Derary", "Djenne", "Fakala", "Macina", "Femaye"],
+        "culture": "manden"
+    },
+    "Taghaza": {
+        "settlements": ["Kerzaz", "Aougrout", "Charouine", "Reggane", "Metarta", "Adrar"],
+        "culture": "maghreb_arabic"
+    },
+    "Araouane": {
+        "settlements": ["Tazrouk", "Tessalit", "Tamanrasset", "Abalessa", "Guezzam", "Aguelhok", "Tinzaouten"],
+        "culture": "maghreb_arabic"
+    },
+    "Sijilmasa": {
+        "settlements": ["Merzane", "Tanamouste", "Tadaout", "Tisserdmine", "Ertoud", "Sijilmasa", "Hannabou", "Merzouga"],
+        "culture": "maghreb_arabic"
+    },
+    "Oualata": {
+        "settlements": ["Tiguiguil", "Tarhalet", "Fassekra", "Konou", "Tizert"],
+        "culture": "manden"
+    },
+    "Breda": {
+        "settlements": ["Willemstad", "Breda", "Ravenstein", "Bergenopzoom", "Cuijck", "Shertogenbosch", "Horn"],
+        "culture": "old_frankish"
+    },
+    "Ouadane": {
+        "settlements": ["Azuggi"],
+        "culture": "maghreb_arabic"
+    },
+    "Idjil": {
+        "settlements": ["Tazadit", "Rouessa"],
+        "culture": "maghreb_arabic"
+    },
+    "Tadmekka": {
+        "settlements": ["Essako", "Kidal", "Takedda", "Agades"],
+        "culture": "manden"
+    },
+    "Mali": {
+        "settlements": ["Niani", "Bougouni", "Baguineda", "Bamako", "Safo", "Soussa", "Boure", "Dialakoro"],
+        "culture": "manden"
+    },
+    "Bambuk": {
+        "settlements": ["Boumdeid", "Bambuk", "Kankossa", "Aftout", "Guerou", "Kiffa"],
+        "culture": "manden"
+    },
+    "Zarma": {
+        "settlements": ["Bura", "Ouallam", "Tera"],
+        "culture": "manden"
+    },
+    "Gurma": {
+        "settlements": ["Zorgho", "Hounde", "Gurma"],
+        "culture": "manden"
+    },
+    "Aprutium": {
+        "settlements": ["Chieti", "Pescara", "Avezzano"],
+        "culture": "lombard"
+    },
+    "Gent": {
+        "settlements": ["St Niklaas", "Dendermonde", "Oudenaarde", "Aalst", "Kortrijk", "Gent", "Geraarsbergen", "Doornik"],
+        "culture": "old_frankish"
+    },
+    "Bar": {
+        "settlements": [],
+        "culture": "old_frankish"
+    },
+    "More": {
+        "settlements": ["Kalmar Hus", "Kalmar"],
+        "culture": "norse"
+    },
+    "Tjust": {
+        "settlements": ["Tornsfall", "Vastervik"],
+        "culture": "norse"
+    },
+    "Roslavl": {
+        "settlements": ["Roslavl", "Chocimsk", "Pochinok"],
+        "culture": "severian"
+    },
+    "Lepiel": {
+        "settlements": ["Chashniki", "Novolukoml", "Lepiel"],
+        "culture": "ilmenian"
+    },
+    "Amalfi": {
+        "settlements": ["Ravello", "Sorrento", "Tramonti", "Amalfi"],
+        "culture": "greek"
+    },
+    "Hainaut": {
+        "settlements": ["Valenciennes", "Mons", "Enghien", "Charleroi", "Avesnes", "Ath", "Cambrai", "Chievres"],
+        "culture": "old_frankish"
+    },
+    "Amiens": {
+        "settlements": ["Soissons", "Peronne", "Montdidier", "Breteuil", "Corbie", "Amiens", "Beauvais", "Noyon"],
+        "culture": "old_frankish"
+    },
+    "Eu": {
+        "settlements": ["Neufchatel-En-Bray", "Forges", "Aumale", "Mortemer", "Serqueux", "Gournay", "Eu", "Drincourt"],
+        "culture": "old_frankish"
+    },
+    "Arques": {
+        "settlements": ["Rouen", "Lillebonne", "Fecamp", "Arques"],
+        "culture": "old_frankish"
+    },
+    "Vexin": {
+        "settlements": ["Mantes", "Harcourt", "Abbayedemortemer", "Larocheguyon", "Louviers", "Ivry", "Gisors", "Pontoise"],
+        "culture": "old_frankish"
+    },
+    "Evreux": {
+        "settlements": ["Argentan", "Sees", "Alencon", "Falaise", "Lisieux", "Evreux", "Honfleur", "Verneuil"],
+        "culture": "old_frankish"
+    },
+    "": {
+        "settlements": [],
+        "culture": ""
+    }
+}

--- a/provinces.json
+++ b/provinces.json
@@ -3009,7 +3009,7 @@
     },
     "Kola": {
         "settlements": ["Jekanskoi", "Tre", "Pechenga", "Lovozero", "Waranger", "Molovskoi", "Mafelskoi"],
-        "culture": "not_lappish"
+        "culture": "tbd"
     },
     "Finnmárk": {
         "settlements": ["Ákŋoluokta", "Álaheadju", "Báhcavuotna", "Bearalváhki", "Čáhcesuolu", "Davvesiida", "Davvinjárga", "Deatnu", "Fálesnuorri", "Gáŋgaviika", "Guovdageaidnu", "Hámmárfeasta", "Kárášjohka", "Láhppi", "Mátta-Várjjat", "Muosát", "Porsáŋgu", "Unjárga", "Várggát"],
@@ -3033,11 +3033,11 @@
     },
     "Onega": {
         "settlements": ["Ust-Onega", "Segezha", "Pryazha", "Aunus", "Petrozavodsk", "Pudoga", "Kondopoga"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Trans-Portage": {
         "settlements": ["Nyandoma", "Konosha", "Plesetsk", "Obozerskiy", "Samoded", "Shenkursk", "Solovetsky"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "North Dvina": {
         "settlements": ["Solvychegodsk", "Antonievosiysky", "Archangelsk", "Usolsk", "Novokholmogory", "Koryazhma", "Nikolokorelski"],
@@ -3081,19 +3081,19 @@
     },
     "Romny": {
         "settlements": ["Ugol", "Vysokaya", "Bykovskaya", "Kholuy", "Vozhega", "Yuchka", "Marinskaya"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Zaozerye": {
         "settlements": ["Nazankha", "Afoninskaya", "Bolshaya", "Konechnaya", "Borisovskaya", "Zarechnaya", "Pashuchikha", "Kharovsk"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Chud": {
         "settlements": ["Zalese", "Zaytsevo", "Krbor", "Veldvor", "Chunlovka", "Krutayaosyp", "Kamchuga"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Vologda": {
         "settlements": ["Motyn", "Bolshayamurga", "Dvinitsa", "Sokol", "Staroye", "Kadnikovskaya"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Kostroma": {
         "settlements": ["Zavolzhsk", "Nerektha", "Kosmynino", "Nekrasoskoye", "Sudislavl", "Apraksino", "Plyos"],
@@ -3101,7 +3101,7 @@
     },
     "Beloozero": {
         "settlements": ["Fedosyevo", "Khoklovo", "Babayevo", "Glushkovo", "Kirillobelozersky", "Kinilov", "Kaduy"],
-        "culture": "not_finnish"
+        "culture": "tbd"
     },
     "Bezhetsky Verh": {
         "settlements": ["Rameshki", "Obrosovo", "Bezhetsk", "Maksatikha", "Spasnakholmu", "Molokovo", "Sonkovo", "Kyasovagora"],
@@ -5080,8 +5080,8 @@
         "culture": "frisian"
     },
     "Kandalax": {
-        "settlements": ["Sarapo", "Pyaozero", "Ponoy", "Kantalahti", "Kolsky", "Umba", "Lekastrom", "Varzuga"],
-        "culture": "not_lappish"
+        "settlements": ["Sarapo", "Pyaozero", "Ponoy", "Kandalaksha", "Kolsky", "Umba", "Lekastrom", "Varzuga"],
+        "culture": "tbd"
     },
     "Capua": {
         "settlements": ["Gaeta", "Calvi", "Capua", "Montecassino", "Acerra", "Teano", "Caserta"],


### PR DESCRIPTION
In the provinces.json, some of the provinces tagged Finnish had Swedish or Russian names. Likewise, the provinces tagged "Lappish" had names in Norwegian, Swedish, Finnish and Russian. 
This changes the names in "Lappish" culture to Northern Sami names and the names in Finnish culture to Finnish names. The names that could be translated were translated, a lot more names were added for both languages, and provinces with names that I could not find any translations for were reclassified as "not_lappish" and "not_finnish" to prevent them skewing the results. They should probably be added to some Russian culture but I don't know which.

Utf-8 support is also included to enable proper spellings for Finnish and Sami names and markovify seems to handle unicode just fine. I don't know if there are some more subtle problems that using unicode in the provinces.json could cause, other than that there are names in other languages that use non-ascii characters that are still left with the ascii version of their name and need updating.